### PR TITLE
feat(proxy): estimate prompt-cache switch costs

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -1437,17 +1437,22 @@ def get_billed_token_rates(
     vertex_location: str | None = None,
     current_time: datetime | None = None,
     custom_cost_per_token: CostPerToken | None = None,
+    model_info: ModelInfo | None = None,
 ) -> BilledTokenRates | None:
     """Rates the cost calculator bills ``usage`` at, resolved exactly as the totals and the token-type
     breakdown resolve them. None when the model's pricing cannot be resolved."""
     if custom_cost_per_token is not None:
         return _custom_pricing_rates(custom_cost_per_token)
     try:
-        model_info: Final = get_model_info(model=model, custom_llm_provider=custom_llm_provider)
+        effective_model_info: Final = (
+            model_info
+            if model_info is not None
+            else get_model_info(model=model, custom_llm_provider=custom_llm_provider)
+        )
     except Exception:  # noqa: BLE001  # get_model_info raises a bare Exception for an unmapped model: no rates
         return None
     return _cost_map_billed_rates(
-        model_info=model_info,
+        model_info=effective_model_info,
         usage=usage,
         custom_llm_provider=custom_llm_provider,
         service_tier=service_tier,

--- a/litellm/litellm_core_utils/prompt_cache_prediction.py
+++ b/litellm/litellm_core_utils/prompt_cache_prediction.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from itertools import accumulate
+from typing import Final, Literal, TypeAlias
+
+from litellm.caching.dual_cache import DualCache
+from litellm.litellm_core_utils.llm_cost_calc.utils import parse_prompt_tokens_details
+from litellm.types.utils import Usage
+from litellm.utils import get_prompt_cache_min_tokens, token_counter
+
+PredictionState: TypeAlias = Literal["warm", "partial", "stale", "unknown", "disabled"]
+_FIVE_MINUTES: Final = 300
+_ONE_HOUR: Final = 3600
+_OBSERVATION_TTL: Final = 7200
+_LOOKBACK: Final = 20
+_MAX_BODY_BYTES: Final = 2_000_000
+_MAX_SEGMENTS: Final = 4096
+_NAMESPACE: Final = "prompt-cache-prediction:v1"
+_CONFIG_FIELDS: Final = ("tool_choice", "speed", "service_tier", "inference_geo", "output_config")
+_UNSUPPORTED_FIELDS: Final = ("thinking", "context_management", "mcp_servers", "container", "compaction")
+_ALLOWED_BLOCK_TYPES: Final = frozenset(("text", "tool_use", "tool_result"))
+
+
+@dataclass(frozen=True, slots=True)
+class PromptCacheTokenBudget:
+    cache_read_input_tokens: int
+    cache_creation_input_tokens_5m: int
+    cache_creation_input_tokens_1h: int
+    uncached_input_tokens: int
+
+
+@dataclass(frozen=True, slots=True)
+class PromptCacheBoundary:
+    index: int
+    digest: str
+    estimated_tokens: int
+    ttl_seconds: int
+
+
+@dataclass(frozen=True, slots=True)
+class PromptCachePlan:
+    model: str
+    boundaries: tuple[PromptCacheBoundary, ...]
+    final_checkpoint_index: int
+    final_ttl_seconds: int
+    total_estimated_tokens: int
+    candidate_count: int
+    current_min_tokens: int
+
+    @property
+    def final_boundary(self) -> PromptCacheBoundary:
+        return next(boundary for boundary in reversed(self.boundaries) if boundary.index == self.final_checkpoint_index)
+
+    def cold_budget(self) -> PromptCacheTokenBudget:
+        final_tokens: Final = self.final_boundary.estimated_tokens
+        return PromptCacheTokenBudget(
+            0,
+            final_tokens if self.final_ttl_seconds == _FIVE_MINUTES else 0,
+            final_tokens if self.final_ttl_seconds == _ONE_HOUR else 0,
+            max(self.total_estimated_tokens - final_tokens, 0),
+        )
+
+    def fully_warm_budget(self) -> PromptCacheTokenBudget:
+        final_tokens: Final = self.final_boundary.estimated_tokens
+        return PromptCacheTokenBudget(final_tokens, 0, 0, max(self.total_estimated_tokens - final_tokens, 0))
+
+
+@dataclass(frozen=True, slots=True)
+class Prediction:
+    state: PredictionState
+    cache_read_input_tokens: int
+    cache_creation_input_tokens_5m: int
+    cache_creation_input_tokens_1h: int
+    uncached_input_tokens: int
+    as_of: float | None
+    expires_at: float | None
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class _Segment:
+    serialized: str
+    ttl: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class _Observation:
+    provider_tokens: int
+    estimated_tokens: int
+    observed_at: float
+    expires_at: float
+    ttl_seconds: int
+
+
+def _serialize(value: object) -> str | None:
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+    except (TypeError, ValueError):
+        return None
+
+
+def _ttl(control: object) -> int | None:
+    if not isinstance(control, Mapping) or control.get("type") != "ephemeral":
+        return None
+    ttl: Final = control.get("ttl", "5m")
+    return _FIVE_MINUTES if ttl == "5m" else _ONE_HOUR if ttl == "1h" else None
+
+
+def _without_marker(value: Mapping[object, object]) -> Mapping[object, object]:
+    return {  # mutable-ok: JSON serialization needs the original mapping shape without its marker
+        key: item for key, item in value.items() if key != "cache_control"
+    }
+
+
+def _segment(value: object, context: tuple[object, ...], marker: object = None) -> _Segment | None:
+    normalized: Final = _without_marker(value) if isinstance(value, Mapping) else value
+    serialized: Final = _serialize((context, normalized))
+    ttl: Final = _ttl(marker) if marker is not None else None
+    return None if serialized is None or (marker is not None and ttl is None) else _Segment(serialized, ttl)
+
+
+def _tools(value: object) -> tuple[_Segment, ...] | None:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return None
+    tools: Final = tuple(value)
+    if any(
+        not isinstance(tool, Mapping)
+        or not isinstance(tool.get("name"), str)
+        or not isinstance(tool.get("input_schema"), Mapping)
+        or tool.get("type", "custom") != "custom"
+        for tool in tools
+    ):
+        return None
+    parsed: Final = tuple(
+        _segment(tool, ("tool", index), tool.get("cache_control"))
+        for index, tool in enumerate(tool for tool in tools if isinstance(tool, Mapping))
+    )
+    return None if any(item is None for item in parsed) else tuple(item for item in parsed if item is not None)
+
+
+def _system(value: object) -> tuple[_Segment, ...] | None:
+    if value is None:
+        return ()
+    blocks: Final = (value,) if isinstance(value, str) else tuple(value) if isinstance(value, Sequence) else ()
+    if not blocks:
+        return None
+    parsed: Final = tuple(
+        _segment(
+            ("text", block) if isinstance(block, str) else block,
+            ("system", index),
+            block.get("cache_control") if isinstance(block, Mapping) else None,
+        )
+        for index, block in enumerate(blocks)
+    )
+    return None if any(item is None for item in parsed) else tuple(item for item in parsed if item is not None)
+
+
+def _valid_block(block: object) -> bool:
+    if isinstance(block, str):
+        return True
+    if not isinstance(block, Mapping) or block.get("type") not in _ALLOWED_BLOCK_TYPES:
+        return False
+    block_type: Final = block.get("type")
+    if block_type == "text":
+        return isinstance(block.get("text"), str)
+    if block_type == "tool_use":
+        return all(isinstance(block.get(field), str) for field in ("id", "name")) and isinstance(
+            block.get("input"), Mapping
+        )
+    content: Final = block.get("content")
+    return isinstance(block.get("tool_use_id"), str) and (
+        isinstance(content, str)
+        or (
+            isinstance(content, Sequence)
+            and not isinstance(content, (str, bytes, bytearray))
+            and all(isinstance(item, Mapping) and item.get("type") == "text" for item in content)
+        )
+    )
+
+
+def _message(message: object, message_index: int) -> tuple[_Segment, ...] | None:
+    if not isinstance(message, Mapping) or message.get("role") not in ("user", "assistant"):
+        return None
+    role: Final = message.get("role")
+    content: Final = message.get("content")
+    blocks: Final = (content,) if isinstance(content, str) else tuple(content) if isinstance(content, Sequence) else ()
+    if not isinstance(role, str) or not blocks or not all(_valid_block(block) for block in blocks):
+        return None
+    parsed: Final = tuple(
+        _segment(
+            ("text", block) if isinstance(block, str) else block,
+            ("message", message_index, index, role),
+            block.get("cache_control") if isinstance(block, Mapping) else None,
+        )
+        for index, block in enumerate(blocks)
+    )
+    if any(item is None for item in parsed):
+        return None
+    segments: Final = tuple(item for item in parsed if item is not None)
+    if "cache_control" not in message:
+        return segments
+    message_ttl: Final = _ttl(message["cache_control"])
+    return (
+        None
+        if message_ttl is None or any(item.ttl is not None for item in segments)
+        else (*segments[:-1], replace(segments[-1], ttl=message_ttl))
+    )
+
+
+def _messages(value: object) -> tuple[_Segment, ...] | None:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return None
+    parsed: Final = tuple(_message(message, index) for index, message in enumerate(value))
+    if not parsed:
+        return None
+    valid: Final = tuple(items for items in parsed if items is not None)
+    return None if len(valid) != len(parsed) else tuple(item for items in valid for item in items)
+
+
+def make_plan(body: object) -> PromptCachePlan | None:
+    if not isinstance(body, Mapping):
+        return None
+    serialized_body: Final = _serialize(body)
+    if serialized_body is None or len(serialized_body.encode()) > _MAX_BODY_BYTES:
+        return None
+    model: Final = body.get("model")
+    if (
+        not isinstance(model, str)
+        or "claude-" not in model
+        or any(field in body and body[field] is not None for field in _UNSUPPORTED_FIELDS)
+    ):
+        return None
+    output_config: Final = body.get("output_config")
+    if output_config is not None and (
+        not isinstance(output_config, Mapping) or frozenset(output_config) - frozenset(("effort",))
+    ):
+        return None
+    envelope: Final = _serialize((model, tuple((field, body[field]) for field in _CONFIG_FIELDS if field in body)))
+    tools: Final = _tools(body.get("tools"))
+    system: Final = _system(body.get("system"))
+    messages: Final = _messages(body.get("messages"))
+    if envelope is None or tools is None or system is None or messages is None:
+        return None
+    segments: Final = (*tools, *system, *messages)
+    if len(segments) > _MAX_SEGMENTS:
+        return None
+    explicit: Final = tuple((index, item.ttl) for index, item in enumerate(segments) if item.ttl is not None)
+    root_control: Final = body.get("cache_control")
+    root_ttl: Final = _ttl(root_control) if root_control is not None else None
+    if root_control is not None and root_ttl is None:
+        return None
+    automatic: Final = ((len(segments) - 1, root_ttl),) if root_ttl is not None else ()
+    markers: Final = (*explicit, *automatic)
+    ttl_values: Final = frozenset(ttl for _, ttl in markers)
+    marked: Final = tuple(sorted(frozenset(index for index, _ in markers)))
+    if len(marked) != 1 or len(ttl_values) != 1:
+        return None
+    uniform_ttl: Final = next(iter(ttl_values))
+    marker: Final = marked[0]
+    eligible: Final = tuple(range(max(0, marker - _LOOKBACK + 1), marker + 1))
+    envelope_digest: Final = hashlib.sha256(envelope.encode()).digest()
+    digest_chain: Final = tuple(
+        accumulate(
+            (item.serialized.encode() for item in segments),
+            lambda digest, item: hashlib.sha256(digest + len(item).to_bytes(8, "big") + item).digest(),
+            initial=envelope_digest,
+        )
+    )[1:]
+    digests: Final = tuple(digest_chain[index].hex() for index in eligible)
+    try:
+        envelope_tokens: Final = token_counter(model=model, text=envelope)
+        segment_estimates: Final = tuple(token_counter(model=model, text=segment.serialized) for segment in segments)
+    except Exception:
+        return None
+    if envelope_tokens <= 0 or any(estimate <= 0 for estimate in segment_estimates):
+        return None
+    cumulative_estimates: Final = tuple(envelope_tokens + estimate for estimate in accumulate(segment_estimates))
+    estimates: Final = tuple(cumulative_estimates[index] for index in eligible)
+    total: Final = cumulative_estimates[-1]
+    try:
+        minimum: Final = get_prompt_cache_min_tokens(model=model)
+    except Exception:
+        return None
+    boundaries: Final = tuple(
+        PromptCacheBoundary(index, digest, estimate, uniform_ttl)
+        for index, digest, estimate in zip(eligible, digests, estimates)
+    )
+    return PromptCachePlan(model, boundaries, marker, uniform_ttl, total, len(boundaries), minimum)
+
+
+def _usage(usage: Mapping[str, object]) -> tuple[int, int, int, int] | None:
+    try:
+        parsed: Final = parse_prompt_tokens_details(Usage(**usage))  # mutable-ok: Pydantic validates the usage copy
+    except Exception:  # noqa: BLE001  # malformed provider telemetry means no observation
+        return None
+    read: Final = parsed["cache_hit_tokens"]
+    write: Final = parsed["cache_creation_tokens"]
+    details: Final = parsed["cache_creation_token_details"]
+    five: Final = details.ephemeral_5m_input_tokens or 0 if details is not None else 0
+    hour: Final = details.ephemeral_1h_input_tokens or 0 if details is not None else 0
+    return (read, write, five, hour) if five + hour == write else None
+
+
+def _key(scope: str, deployment_id: str, model: str, digest: str) -> str:
+    identity: Final = _serialize((_NAMESPACE, scope, deployment_id, model, digest)) or ""
+    return f"{_NAMESPACE}:{hashlib.sha256(identity.encode()).hexdigest()}"
+
+
+def _observation(value: object) -> _Observation | None:
+    try:
+        decoded: Final = json.loads(value) if isinstance(value, str) else value
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(decoded, Sequence) or isinstance(decoded, (str, bytes, bytearray)) or len(decoded) != 5:
+        return None
+    provider, estimate, observed, expires, ttl = decoded
+    if (
+        not isinstance(provider, int)
+        or isinstance(provider, bool)
+        or provider <= 0
+        or not isinstance(estimate, int)
+        or isinstance(estimate, bool)
+        or estimate <= 0
+        or not isinstance(observed, (int, float))
+        or isinstance(observed, bool)
+        or not isinstance(expires, (int, float))
+        or isinstance(expires, bool)
+        or ttl not in (_FIVE_MINUTES, _ONE_HOUR)
+    ):
+        return None
+    return _Observation(provider, estimate, float(observed), float(expires), ttl)
+
+
+def _value(observation: _Observation) -> str:
+    return (
+        _serialize(
+            (
+                observation.provider_tokens,
+                observation.estimated_tokens,
+                observation.observed_at,
+                observation.expires_at,
+                observation.ttl_seconds,
+            )
+        )
+        or ""
+    )
+
+
+async def observe(
+    cache: DualCache,
+    scope: str,
+    deployment_id: str,
+    plan: PromptCachePlan,
+    usage: Mapping[str, object],
+    started_at: float,
+) -> None:
+    counts: Final = _usage(usage)
+    if not scope or not deployment_id or not math.isfinite(started_at) or counts is None:
+        return
+    read, write, five, hour = counts
+    if read <= 0 and write <= 0:
+        return
+    boundary: Final = plan.final_boundary
+    key: Final = _key(scope, deployment_id, plan.model, boundary.digest)
+    if write > 0:
+        matching_write: Final = five if plan.final_ttl_seconds == _FIVE_MINUTES else hour
+        if matching_write != write:
+            return
+        observation: Final = _Observation(
+            read + write,
+            boundary.estimated_tokens,
+            started_at,
+            started_at + plan.final_ttl_seconds,
+            plan.final_ttl_seconds,
+        )
+        await cache.async_set_cache(key, _value(observation), ttl=_OBSERVATION_TTL)
+        return
+    existing: Final = _observation(await cache.async_get_cache(key))
+    if existing is None or existing.provider_tokens != read or existing.estimated_tokens != boundary.estimated_tokens:
+        return
+    refreshed: Final = replace(existing, observed_at=started_at, expires_at=started_at + existing.ttl_seconds)
+    await cache.async_set_cache(key, _value(refreshed), ttl=_OBSERVATION_TTL)
+
+
+def _prediction(
+    state: PredictionState, budget: PromptCacheTokenBudget, reason: str, observation: _Observation | None = None
+) -> Prediction:
+    return Prediction(
+        state,
+        budget.cache_read_input_tokens,
+        budget.cache_creation_input_tokens_5m,
+        budget.cache_creation_input_tokens_1h,
+        budget.uncached_input_tokens,
+        observation.observed_at if observation else None,
+        observation.expires_at if observation else None,
+        reason,
+    )
+
+
+def _cold(
+    plan: PromptCachePlan, state: PredictionState, reason: str, observation: _Observation | None = None
+) -> Prediction:
+    return _prediction(state, plan.cold_budget(), reason, observation)
+
+
+async def predict(cache: DualCache, scope: str, deployment_id: str, plan: PromptCachePlan, now: float) -> Prediction:
+    final: Final = plan.final_boundary
+    if final.estimated_tokens < plan.current_min_tokens:
+        return _prediction(
+            "disabled",
+            PromptCacheTokenBudget(0, 0, 0, plan.total_estimated_tokens),
+            "cacheable_prefix_below_model_minimum",
+        )
+    if not scope or not deployment_id or not math.isfinite(now):
+        return _cold(plan, "unknown", "invalid_scope_deployment_or_time_cold_assumption")
+    boundaries: Final = tuple(reversed(plan.boundaries))
+    values: Final = await cache.async_batch_get_cache(
+        list(
+            _key(scope, deployment_id, plan.model, item.digest) for item in boundaries
+        )  # mutable-ok: DualCache batch API requires list
+    )
+    if values is None or len(values) != len(boundaries):
+        return _cold(plan, "unknown", "observation_lookup_failed_cold_assumption")
+    parsed: Final = tuple((boundary, value, _observation(value)) for boundary, value in zip(boundaries, values))
+    compatible: Final = tuple(
+        (boundary, observation)
+        for boundary, _, observation in parsed
+        if observation is not None
+        and observation.estimated_tokens == boundary.estimated_tokens
+        and observation.ttl_seconds == plan.final_ttl_seconds
+        and boundary.estimated_tokens <= final.estimated_tokens
+    )
+    live: Final = next(((boundary, item) for boundary, item in compatible if item.expires_at > now), None)
+    if live is not None:
+        boundary, item = live
+        suffix: Final = max(final.estimated_tokens - boundary.estimated_tokens, 0)
+        budget: Final = PromptCacheTokenBudget(
+            item.provider_tokens,
+            suffix if plan.final_ttl_seconds == _FIVE_MINUTES else 0,
+            suffix if plan.final_ttl_seconds == _ONE_HOUR else 0,
+            max(plan.total_estimated_tokens - boundary.estimated_tokens - suffix, 0),
+        )
+        exact: Final = boundary.index == plan.final_checkpoint_index
+        return _prediction(
+            "warm" if exact else "partial",
+            budget,
+            "live_exact_observation" if exact else "live_ancestor_observation",
+            item,
+        )
+    stale: Final = next((item for _, item in compatible if item.expires_at <= now), None)
+    if stale is not None:
+        return _cold(plan, "stale", "compatible_observation_expired", stale)
+    if any(value is not None and item is None for _, value, item in parsed):
+        return _cold(plan, "unknown", "invalid_observation_cold_assumption")
+    return _cold(plan, "unknown", "no_observation_cold_assumption")

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2237,6 +2237,22 @@ class BaseLLMHTTPHandler:
         )
         logging_obj.stream = stream
         logging_obj.model_call_details.update(request_body)
+        from litellm.litellm_core_utils.core_helpers import get_metadata_variable_name_from_kwargs
+        from litellm.litellm_core_utils.prompt_cache_prediction import make_plan
+        from litellm.litellm_core_utils.token_counter import offload_token_count
+
+        metadata_key: Final = get_metadata_variable_name_from_kwargs(kwargs)
+        raw_metadata: Final = kwargs.get(metadata_key)
+        scope: Final = raw_metadata.get("user_api_key_hash") if isinstance(raw_metadata, Mapping) else None
+        model_info: Final = kwargs.get("model_info")
+        model_id: Final = model_info.get("id") if isinstance(model_info, Mapping) else None
+        logging_obj.model_call_details.update(
+            {  # mutable-ok: model_call_details owns a mutable request-scoped payload
+                "prompt_cache_plan": await offload_token_count(make_plan)(request_body),
+                "prompt_cache_observation_scope": scope if isinstance(scope, str) else None,
+                "prompt_cache_observation_model_id": model_id if isinstance(model_id, str) else None,
+            }
+        )
 
         # Make the request
         request_url: Final = anthropic_messages_provider_config.get_complete_url(
@@ -3716,7 +3732,12 @@ class BaseLLMHTTPHandler:
                     data=transformed_request,
                     timeout=timeout,
                 )
-        elif isinstance(transformed_request, dict) and "file" in transformed_request:
+        elif (
+            isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]  # preserve multipart shape guard across provider payloads
+                transformed_request, dict
+            )
+            and "file" in transformed_request
+        ):
             # Handle multipart form-data uploads (e.g., Anthropic Files API)
             # The dict contains tuples suitable for httpx's `files` parameter
             file_request: Final = cast(dict[str, Any], transformed_request)
@@ -3876,7 +3897,12 @@ class BaseLLMHTTPHandler:
                     data=transformed_request,
                     timeout=timeout,
                 )
-        elif isinstance(transformed_request, dict) and "file" in transformed_request:
+        elif (
+            isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]  # preserve multipart shape guard across provider payloads
+                transformed_request, dict
+            )
+            and "file" in transformed_request
+        ):
             # Handle multipart form-data uploads (e.g., Anthropic Files API)
             # The dict contains tuples suitable for httpx's `files` parameter
             upload_response = await async_httpx_client.post(

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -715,6 +715,8 @@ class LiteLLMRoutes(enum.Enum):
         "/management/v1/spend_logs/end_users",
         "/management/v1/spend_logs/users",
         "/cost/estimate",
+        "/cost/estimate/cache-switch",
+        "/cost/estimate/cache-switch/predict",
     ]
 
     global_spend_tracking_routes = [
@@ -5238,6 +5240,87 @@ class CostEstimateRequest(LiteLLMPydanticObjectBase):
         if self.reasoning_tokens > self.output_tokens:
             raise ValueError("reasoning_tokens cannot exceed output_tokens")
         return self
+
+
+class CacheSwitchCostEstimateArmRequest(LiteLLMPydanticObjectBase):
+    model: str = Field(description="Provider-qualified model or configured model group")
+    model_id: str | None = Field(default=None, description="Required when model resolves to multiple deployments")
+    uncached_input_tokens: int = Field(description="Input tokens billed at the normal input rate", ge=0)
+    cache_read_input_tokens: int = Field(description="Input tokens assumed to hit the prompt cache", ge=0)
+    cache_creation_input_tokens_5m: int = Field(description="Input tokens assumed to write a 5-minute cache", ge=0)
+    cache_creation_input_tokens_1h: int = Field(description="Input tokens assumed to write a 1-hour cache", ge=0)
+    assumed_cache_state: Literal["warm", "cold", "stale", "unknown"] | None = Field(
+        default=None, description="Descriptive assumption only; token buckets determine the estimate"
+    )
+
+
+class CacheSwitchPredictionTarget(LiteLLMPydanticObjectBase):
+    model_config = ConfigDict(extra="forbid")
+    model: str
+    model_id: str | None = None
+    prompt: Mapping[str, object] = Field(description="Native Anthropic Messages body, excluding model and credentials")
+
+
+class CacheSwitchPredictionRequest(LiteLLMPydanticObjectBase):
+    model_config = ConfigDict(extra="forbid")
+    stay: CacheSwitchPredictionTarget
+    switch: CacheSwitchPredictionTarget
+
+
+class CacheSwitchPredictionArm(LiteLLMPydanticObjectBase):
+    model: str
+    model_id: str | None
+    cache_state: Literal["warm", "partial", "stale", "unknown", "disabled"]
+    reason: str
+    observed_at: float | None = None
+    expires_at: float | None = None
+    estimated_input_cost: float | None = Field(default=None, description="USD; null when cache evidence is unavailable")
+    cold_input_cost: float | None = None
+    warm_input_cost: float | None = None
+    cache_penalty: float | None = Field(
+        default=None, description="Estimated input cost minus this model's fully warm input cost"
+    )
+    cache_read_input_tokens: int | None = None
+    cache_creation_input_tokens_5m: int | None = None
+    cache_creation_input_tokens_1h: int | None = None
+    uncached_input_tokens: int | None = None
+
+
+class CacheSwitchPredictionResponse(LiteLLMPydanticObjectBase):
+    stay: CacheSwitchPredictionArm
+    switch: CacheSwitchPredictionArm
+    switch_cost_delta: float | None = Field(
+        description="Switch minus stay input cost in USD; null if either state is unknown"
+    )
+    token_count_source: Literal["local_estimate_with_observed_prefix"] = "local_estimate_with_observed_prefix"
+    cache_evidence_source: Literal["gateway_observations"] = "gateway_observations"
+
+
+class CacheSwitchCostEstimateRequest(LiteLLMPydanticObjectBase):
+    stay: CacheSwitchCostEstimateArmRequest
+    switch: CacheSwitchCostEstimateArmRequest
+
+
+class CacheSwitchCostEstimateArmResponse(CacheSwitchCostEstimateArmRequest):
+    resolved_model: str
+    resolved_model_id: str | None
+    provider: str | None
+    input_tokens: int
+    input_cost: float = Field(description="Estimated input cost in USD")
+    uncached_input_cost: float
+    cache_read_input_cost: float
+    cache_creation_input_cost_5m: float
+    cache_creation_input_cost_1h: float
+    input_cost_per_token: float
+    cache_read_input_token_cost: float
+    cache_creation_input_token_cost_5m: float
+    cache_creation_input_token_cost_1h: float
+
+
+class CacheSwitchCostEstimateResponse(LiteLLMPydanticObjectBase):
+    stay: CacheSwitchCostEstimateArmResponse
+    switch: CacheSwitchCostEstimateArmResponse
+    switch_cost_delta: float = Field(description="Switch input cost minus stay input cost in USD")
 
 
 class CostEstimateResponse(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/management_endpoints/cache_switch_cost_estimate.py
+++ b/litellm/proxy/management_endpoints/cache_switch_cost_estimate.py
@@ -1,0 +1,377 @@
+import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from types import MappingProxyType
+from typing import Final
+
+from fastapi import APIRouter, Depends, HTTPException
+
+import litellm
+from litellm._internal_context import current_billing_time
+from litellm.litellm_core_utils.llm_cost_calc.utils import get_billed_token_rates
+from litellm.litellm_core_utils.prompt_cache_prediction import (
+    Prediction,
+    PromptCacheTokenBudget,
+    make_plan,
+    predict,
+)
+from litellm.litellm_core_utils.token_counter import offload_token_count
+from litellm.proxy._types import (
+    CacheSwitchCostEstimateArmRequest,
+    CacheSwitchCostEstimateArmResponse,
+    CacheSwitchCostEstimateRequest,
+    CacheSwitchCostEstimateResponse,
+    CacheSwitchPredictionArm,
+    CacheSwitchPredictionRequest,
+    CacheSwitchPredictionResponse,
+    CacheSwitchPredictionTarget,
+    UserAPIKeyAuth,
+)
+from litellm.proxy.auth.auth_checks import can_key_call_resolved_model
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.types.utils import CacheCreationTokenDetails, PromptTokensDetailsWrapper, Usage
+
+router: Final = APIRouter()
+_USER_API_KEY_AUTH_DEPENDENCY: Final = Depends(user_api_key_auth)
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedModel:
+    model: str
+    model_id: str | None
+    provider: str | None
+
+
+def _resolved_direct_model(model: str) -> _ResolvedModel:
+    try:
+        resolved_model, provider, _, _ = litellm.get_llm_provider(model=model)
+    except Exception as error:
+        raise HTTPException(
+            status_code=404,
+            detail={  # mutable-ok: HTTPException detail is a public response mapping
+                "error": f"Could not price model '{model}'"
+            },
+        ) from error
+    return _ResolvedModel(model=resolved_model, model_id=None, provider=provider)
+
+
+def _resolved_deployment(model: str, model_id: str | None) -> _ResolvedModel:
+    from litellm.proxy.proxy_server import llm_router
+
+    if llm_router is None:
+        if model_id is not None:
+            raise HTTPException(
+                status_code=422,
+                detail={  # mutable-ok: HTTPException detail is a public response mapping
+                    "error": f"Unknown model_id '{model_id}'"
+                },
+            )
+        return _resolved_direct_model(model)
+    deployments: Final = tuple(llm_router.get_model_list(model_name=model) or ())
+    if model_id is None and len(deployments) > 1:
+        raise HTTPException(
+            status_code=422,
+            detail={  # mutable-ok: HTTPException detail is a public response mapping
+                "error": f"Model '{model}' resolves to multiple deployments; provide model_id"
+            },
+        )
+    matches: Final = (
+        deployments
+        if model_id is None
+        else tuple(
+            deployment
+            for deployment in deployments
+            if (deployment.get("model_info") or {}).get("id")  # mutable-ok: router metadata mapping
+            == model_id
+        )
+    )
+    if model_id is not None and len(matches) != 1:
+        raise HTTPException(
+            status_code=422,
+            detail={  # mutable-ok: HTTPException detail is a public response mapping
+                "error": f"model_id '{model_id}' does not uniquely identify a deployment for model '{model}'"
+            },
+        )
+    if not matches:
+        return _resolved_direct_model(model)
+    deployment: Final = matches[0]
+    params: Final = (
+        deployment.get("litellm_params") or {}  # mutable-ok: router params mapping
+    )
+    info: Final = deployment.get("model_info") or {}  # mutable-ok: deployment info default is a read-only local view
+    backend: Final = info.get("base_model") or params.get("base_model") or params.get("model")
+    if not isinstance(backend, str):
+        raise HTTPException(
+            status_code=422,
+            detail={  # mutable-ok: HTTPException detail is a public response mapping
+                "error": f"Could not resolve model '{model}'"
+            },
+        )
+    resolved_model, provider, _, _ = litellm.get_llm_provider(
+        model=backend,
+        custom_llm_provider=params.get("custom_llm_provider"),
+    )
+    resolved_id: Final = info.get("id")
+    return _ResolvedModel(
+        model=resolved_model,
+        model_id=resolved_id if isinstance(resolved_id, str) else None,
+        provider=provider,
+    )
+
+
+def _usage(request: CacheSwitchCostEstimateArmRequest) -> Usage:
+    creation: Final = request.cache_creation_input_tokens_5m + request.cache_creation_input_tokens_1h
+    total: Final = request.uncached_input_tokens + request.cache_read_input_tokens + creation
+    return Usage(
+        prompt_tokens=total,
+        completion_tokens=0,
+        total_tokens=total,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            text_tokens=request.uncached_input_tokens,
+            cached_tokens=request.cache_read_input_tokens,
+            cache_creation_tokens=creation,
+            cache_creation_token_details=CacheCreationTokenDetails(
+                ephemeral_5m_input_tokens=request.cache_creation_input_tokens_5m,
+                ephemeral_1h_input_tokens=request.cache_creation_input_tokens_1h,
+            ),
+        ),
+    )
+
+
+def _estimate_arm(
+    request: CacheSwitchCostEstimateArmRequest, billing_time: datetime
+) -> CacheSwitchCostEstimateArmResponse:
+    from litellm.proxy.proxy_server import llm_router
+
+    resolved: Final = _resolved_deployment(request.model, request.model_id)
+    usage: Final = _usage(request)
+    model_info: Final = (
+        llm_router.get_deployment_model_info(resolved.model_id, resolved.model)
+        if llm_router is not None and resolved.model_id is not None
+        else None
+    )
+    rates: Final = get_billed_token_rates(
+        model=resolved.model,
+        custom_llm_provider=resolved.provider,
+        usage=usage,
+        current_time=billing_time,
+        model_info=model_info,
+    )
+    if rates is None:
+        raise HTTPException(
+            status_code=404,
+            detail={  # mutable-ok: HTTPException detail is a public response mapping
+                "error": f"Could not price model '{request.model}'"
+            },
+        )
+    effective_info: Final = model_info or litellm.get_model_info(
+        model=resolved.model,
+        custom_llm_provider=resolved.provider,
+    )
+    missing_rate: Final = next(
+        (
+            label
+            for tokens, label, key in (
+                (request.uncached_input_tokens, "input", "input_cost_per_token"),
+                (request.cache_read_input_tokens, "cache read", "cache_read_input_token_cost"),
+                (request.cache_creation_input_tokens_5m, "5-minute cache write", "cache_creation_input_token_cost"),
+                (
+                    request.cache_creation_input_tokens_1h,
+                    "1-hour cache write",
+                    "cache_creation_input_token_cost_above_1hr",
+                ),
+            )
+            if tokens > 0 and effective_info.get(key) is None
+        ),
+        None,
+    )
+    if missing_rate is not None:
+        raise HTTPException(
+            status_code=422,
+            detail={  # mutable-ok: HTTPException detail is a public response mapping
+                "error": f"Model '{request.model}' has no {missing_rate} rate"
+            },
+        )
+    uncached: Final = request.uncached_input_tokens * rates.input_cost_per_token
+    cache_read: Final = request.cache_read_input_tokens * rates.cache_read_input_token_cost
+    write_5m: Final = request.cache_creation_input_tokens_5m * rates.cache_creation_input_token_cost
+    write_1h: Final = request.cache_creation_input_tokens_1h * rates.cache_creation_input_token_cost_above_1hr
+    return CacheSwitchCostEstimateArmResponse(
+        **request.model_dump(),
+        resolved_model=resolved.model,
+        resolved_model_id=resolved.model_id,
+        provider=resolved.provider,
+        input_tokens=usage.prompt_tokens,
+        input_cost=uncached + cache_read + write_5m + write_1h,
+        uncached_input_cost=uncached,
+        cache_read_input_cost=cache_read,
+        cache_creation_input_cost_5m=write_5m,
+        cache_creation_input_cost_1h=write_1h,
+        input_cost_per_token=rates.input_cost_per_token,
+        cache_read_input_token_cost=rates.cache_read_input_token_cost,
+        cache_creation_input_token_cost_5m=rates.cache_creation_input_token_cost,
+        cache_creation_input_token_cost_1h=rates.cache_creation_input_token_cost_above_1hr,
+    )
+
+
+@router.post(
+    "/cost/estimate/cache-switch",
+    tags=("Cost Tracking",),
+    dependencies=(Depends(user_api_key_auth),),
+    response_model=CacheSwitchCostEstimateResponse,
+)
+async def estimate_cache_switch_cost(
+    request: CacheSwitchCostEstimateRequest,
+    user_api_key_dict: UserAPIKeyAuth = _USER_API_KEY_AUTH_DEPENDENCY,
+) -> CacheSwitchCostEstimateResponse:
+    billing_time: Final = current_billing_time()
+    stay: Final = _estimate_arm(request.stay, billing_time)
+    switch: Final = _estimate_arm(request.switch, billing_time)
+    return CacheSwitchCostEstimateResponse(
+        stay=stay,
+        switch=switch,
+        switch_cost_delta=switch.input_cost - stay.input_cost,
+    )
+
+
+def _prediction_prompt(target: CacheSwitchPredictionTarget, resolved: _ResolvedModel) -> Mapping[str, object]:
+    return {**target.prompt, "model": resolved.model}  # mutable-ok: native JSON body passed to the serializer
+
+
+def _prediction_arm(
+    target: CacheSwitchPredictionTarget,
+    resolved: _ResolvedModel,
+    prediction: Prediction,
+    cold: CacheSwitchCostEstimateArmResponse | None,
+    warm: CacheSwitchCostEstimateArmResponse | None,
+    estimated: CacheSwitchCostEstimateArmResponse | None,
+) -> CacheSwitchPredictionArm:
+    return CacheSwitchPredictionArm(
+        model=resolved.model,
+        model_id=resolved.model_id,
+        cache_state=prediction.state,
+        reason=prediction.reason,
+        observed_at=prediction.as_of,
+        expires_at=prediction.expires_at,
+        estimated_input_cost=estimated.input_cost if estimated is not None else None,
+        cold_input_cost=cold.input_cost if cold is not None else None,
+        warm_input_cost=warm.input_cost if warm is not None else None,
+        cache_penalty=(estimated.input_cost - warm.input_cost if estimated is not None and warm is not None else None),
+        cache_read_input_tokens=prediction.cache_read_input_tokens,
+        cache_creation_input_tokens_5m=prediction.cache_creation_input_tokens_5m,
+        cache_creation_input_tokens_1h=prediction.cache_creation_input_tokens_1h,
+        uncached_input_tokens=prediction.uncached_input_tokens,
+    )
+
+
+async def _predict_target(
+    target: CacheSwitchPredictionTarget, scope: str | None, now: float
+) -> CacheSwitchPredictionArm:
+    from litellm.proxy.proxy_server import llm_router
+
+    resolved: Final = _resolved_deployment(target.model, target.model_id)
+    if llm_router is None or resolved.model_id is None or scope is None:
+        return CacheSwitchPredictionArm(
+            model=resolved.model,
+            model_id=resolved.model_id,
+            cache_state="unknown",
+            reason="concrete_router_deployment_required",
+        )
+    plan: Final = await offload_token_count(make_plan)(_prediction_prompt(target, resolved))
+    if plan is None:
+        return CacheSwitchPredictionArm(
+            model=resolved.model,
+            model_id=resolved.model_id,
+            cache_state="unknown",
+            reason="unsupported_or_ambiguous_prompt_shape",
+        )
+    prediction: Final = await predict(llm_router.cache, scope, resolved.model_id, plan, now)
+    predicted_cacheable: Final = (
+        prediction.cache_read_input_tokens
+        + prediction.cache_creation_input_tokens_5m
+        + prediction.cache_creation_input_tokens_1h
+    )
+    full_cacheable: Final = (
+        plan.final_boundary.estimated_tokens if prediction.state == "unknown" else predicted_cacheable
+    )
+    predicted_uncached: Final = prediction.uncached_input_tokens
+    cold_budget: Final = PromptCacheTokenBudget(
+        0,
+        full_cacheable if plan.final_ttl_seconds == 300 else 0,
+        full_cacheable if plan.final_ttl_seconds == 3600 else 0,
+        predicted_uncached,
+    )
+    warm_budget: Final = PromptCacheTokenBudget(full_cacheable, 0, 0, predicted_uncached)
+    cold_request: Final = CacheSwitchCostEstimateArmRequest(
+        model=target.model,
+        model_id=resolved.model_id,
+        cache_read_input_tokens=cold_budget.cache_read_input_tokens,
+        cache_creation_input_tokens_5m=cold_budget.cache_creation_input_tokens_5m,
+        cache_creation_input_tokens_1h=cold_budget.cache_creation_input_tokens_1h,
+        uncached_input_tokens=cold_budget.uncached_input_tokens,
+        assumed_cache_state="cold",
+    )
+    warm_request: Final = CacheSwitchCostEstimateArmRequest(
+        model=target.model,
+        model_id=resolved.model_id,
+        cache_read_input_tokens=warm_budget.cache_read_input_tokens,
+        cache_creation_input_tokens_5m=warm_budget.cache_creation_input_tokens_5m,
+        cache_creation_input_tokens_1h=warm_budget.cache_creation_input_tokens_1h,
+        uncached_input_tokens=warm_budget.uncached_input_tokens,
+        assumed_cache_state="warm",
+    )
+    predicted_request: Final = CacheSwitchCostEstimateArmRequest(
+        model=target.model,
+        model_id=resolved.model_id,
+        cache_read_input_tokens=prediction.cache_read_input_tokens,
+        cache_creation_input_tokens_5m=prediction.cache_creation_input_tokens_5m,
+        cache_creation_input_tokens_1h=prediction.cache_creation_input_tokens_1h,
+        uncached_input_tokens=prediction.uncached_input_tokens,
+        assumed_cache_state=(
+            "warm" if prediction.state in ("warm", "partial") else "stale" if prediction.state == "stale" else "unknown"
+        ),
+    )
+    billing_time: Final = current_billing_time()
+    cold: Final = _estimate_arm(cold_request, billing_time)
+    warm: Final = _estimate_arm(warm_request, billing_time)
+    estimated: Final = None if prediction.state == "unknown" else _estimate_arm(predicted_request, billing_time)
+    return _prediction_arm(target, resolved, prediction, cold, warm, estimated)
+
+
+@router.post(
+    "/cost/estimate/cache-switch/predict",
+    tags=("Cost Tracking",),
+    dependencies=(Depends(user_api_key_auth),),
+    response_model=CacheSwitchPredictionResponse,
+)
+async def predict_cache_switch_cost(
+    request: CacheSwitchPredictionRequest,
+    user_api_key_dict: UserAPIKeyAuth = _USER_API_KEY_AUTH_DEPENDENCY,
+) -> CacheSwitchPredictionResponse:
+    from litellm.proxy.proxy_server import llm_router
+
+    if llm_router is None:
+        raise HTTPException(
+            status_code=422,
+            detail=MappingProxyType({"error": "A configured Router is required for prediction"}),
+        )
+    for target in (request.stay, request.switch):
+        await can_key_call_resolved_model(
+            model=target.model,
+            llm_model_list=llm_router.get_model_list(model_name=target.model),
+            valid_token=user_api_key_dict,
+            llm_router=llm_router,
+        )
+    now: Final = current_billing_time().timestamp()
+    scope: Final = user_api_key_dict.api_key
+    stay, switch = await asyncio.gather(
+        _predict_target(request.stay, scope, now),
+        _predict_target(request.switch, scope, now),
+    )
+    delta: Final = (
+        switch.estimated_input_cost - stay.estimated_input_cost
+        if switch.estimated_input_cost is not None and stay.estimated_input_cost is not None
+        else None
+    )
+    return CacheSwitchPredictionResponse(stay=stay, switch=switch, switch_cost_delta=delta)

--- a/litellm/proxy/prompt_cache_prediction.py
+++ b/litellm/proxy/prompt_cache_prediction.py
@@ -1,0 +1,89 @@
+from collections.abc import Mapping
+from datetime import datetime
+from types import MappingProxyType
+from typing import Final
+
+from pydantic import BaseModel, ValidationError
+
+from litellm._logging import verbose_proxy_logger
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.prompt_cache_prediction import PromptCachePlan, observe
+
+
+class _CacheObservationLogger(CustomLogger):
+    async def async_log_success_event(
+        self, kwargs: dict, response_obj: object, start_time: datetime, end_time: datetime
+    ) -> None:
+        await _record(kwargs)
+
+    def log_success_event(self, kwargs: dict, response_obj: object, start_time: datetime, end_time: datetime) -> None:
+        _record_sync(kwargs)
+
+
+class _CacheEventMetadata(BaseModel):
+    usage_object: Mapping[str, object] | None = None
+
+
+class _CacheEvent(BaseModel):
+    status: str
+    custom_llm_provider: str | None = None
+    cache_hit: bool | None = None
+    model_id: str | None = None
+    startTime: float
+    metadata: _CacheEventMetadata
+
+
+def _event(kwargs: Mapping[str, object]) -> tuple[_CacheEvent, PromptCachePlan, str, str] | None:
+    plan: Final = kwargs.get("prompt_cache_plan")
+    scope: Final = kwargs.get("prompt_cache_observation_scope")
+    deployment_id: Final = kwargs.get("prompt_cache_observation_model_id")
+    payload: Final = kwargs.get("standard_logging_object")
+    if not isinstance(plan, PromptCachePlan) or not isinstance(scope, str) or not isinstance(deployment_id, str):
+        return None
+    try:
+        event: Final = _CacheEvent.model_validate(payload)
+    except ValidationError:
+        return None
+    if (
+        event.status != "success"
+        or event.custom_llm_provider != "anthropic"
+        or event.cache_hit is True
+        or event.metadata.usage_object is None
+    ):
+        return None
+    return event, plan, scope, deployment_id
+
+
+async def _record(kwargs: Mapping[str, object]) -> None:
+    parsed: Final = _event(kwargs)
+    if parsed is None:
+        return
+    event, plan, scope, deployment_id = parsed
+    from litellm.proxy.proxy_server import llm_router
+
+    if llm_router is None:
+        return
+    try:
+        await observe(
+            llm_router.cache,
+            scope,
+            deployment_id,
+            plan,
+            event.metadata.usage_object or MappingProxyType({}),
+            event.startTime,
+        )
+    except Exception:  # noqa: BLE001  # optional cache telemetry must not interrupt success callbacks
+        verbose_proxy_logger.debug("Could not record prompt cache observation")
+
+
+def _record_sync(kwargs: Mapping[str, object]) -> None:
+    import asyncio
+
+    try:
+        asyncio.run(_record(kwargs))
+    except RuntimeError:
+        verbose_proxy_logger.debug("Could not record synchronous prompt cache observation")
+
+
+def prompt_cache_observation_logger() -> CustomLogger:
+    return _CacheObservationLogger()

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -490,6 +490,9 @@ from litellm.proxy.management_endpoints.budget_management_endpoints import (
 from litellm.proxy.management_endpoints.cache_settings_endpoints import (
     router as cache_settings_router,
 )
+from litellm.proxy.management_endpoints.cache_switch_cost_estimate import (
+    router as cache_switch_cost_estimate_router,
+)
 from litellm.proxy.management_endpoints.callback_management_endpoints import (
     router as callback_management_endpoints_router,
 )
@@ -593,6 +596,7 @@ from litellm.proxy.plugin_routes import (
 from litellm.proxy.plugin_routes import (
     router as plugin_router,
 )
+from litellm.proxy.prompt_cache_prediction import prompt_cache_observation_logger
 from litellm.proxy.spend_tracking.spend_event_producer import (
     CollectorSettings,
     SpendEventProducer,
@@ -2485,6 +2489,8 @@ def cost_tracking():
         spend_event_producer = build_spend_event_producer(CollectorSettings(), fallback=run_spend_event)
         litellm.logging_callback_manager.add_litellm_callback(_ProxyDBLogger(spend_event_producer))
         litellm.logging_callback_manager.add_litellm_async_success_callback(_ProxyDBLogger(spend_event_producer))
+        litellm.logging_callback_manager.add_litellm_callback(prompt_cache_observation_logger())
+        litellm.logging_callback_manager.add_litellm_async_success_callback(prompt_cache_observation_logger())
         litellm.logging_callback_manager.add_litellm_callback(ShadowEvalLogger())
 
 
@@ -18728,6 +18734,7 @@ app.include_router(workflow_management_router)
 app.include_router(memory_router)
 app.include_router(plugin_router)
 app.include_router(cost_tracking_settings_router)
+app.include_router(cache_switch_cost_estimate_router)
 app.include_router(router_settings_router)
 app.include_router(fallback_management_router)
 app.include_router(cache_settings_router)

--- a/tests/test_litellm/litellm_core_utils/test_prompt_cache_prediction.py
+++ b/tests/test_litellm/litellm_core_utils/test_prompt_cache_prediction.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from litellm.caching.dual_cache import DualCache
+from litellm.litellm_core_utils.prompt_cache_prediction import (
+    PromptCachePlan,
+    make_plan,
+    observe,
+    predict,
+)
+
+_MODEL = "claude-opus-4-8"
+_PREFIX = "stable prefix " * 900
+
+
+@pytest.fixture(autouse=True)
+def _local_model_cost_map_autouse(local_model_cost_map):
+    yield
+
+
+def _body(
+    *,
+    messages: list[dict[str, object]] | None = None,
+    tools: list[dict[str, object]] | None = None,
+    system: object = None,
+    ttl: str = "5m",
+    automatic: bool = False,
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "model": _MODEL,
+        "max_tokens": 128,
+        "messages": messages
+        or [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": _PREFIX,
+                        **({} if automatic else {"cache_control": {"type": "ephemeral", "ttl": ttl}}),
+                    }
+                ],
+            }
+        ],
+    }
+    if automatic:
+        body["cache_control"] = {"type": "ephemeral", "ttl": ttl}
+    if tools is not None:
+        body["tools"] = tools
+    if system is not None:
+        body["system"] = system
+    return body
+
+
+def _plan(body: Mapping[str, object]) -> PromptCachePlan:
+    plan = make_plan(body)
+    assert plan is not None
+    return plan
+
+
+def _write_usage(plan: PromptCachePlan) -> dict[str, object]:
+    tokens = plan.final_boundary.estimated_tokens
+    return {
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": tokens,
+        "prompt_tokens_details": {
+            "cached_tokens": 0,
+            "cache_write_tokens": tokens,
+            "cache_creation_tokens": tokens,
+            "cache_creation_token_details": {
+                "ephemeral_5m_input_tokens": tokens if plan.final_ttl_seconds == 300 else 0,
+                "ephemeral_1h_input_tokens": tokens if plan.final_ttl_seconds == 3600 else 0,
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_observed_exact_prefix_is_warm_and_append_is_partial():
+    cache = DualCache()
+    first = _plan(_body())
+    await observe(cache, "scope-a", "deployment-a", first, _write_usage(first), 100.0)
+
+    exact = await predict(cache, "scope-a", "deployment-a", first, 101.0)
+    assert exact.state == "warm"
+    assert exact.cache_read_input_tokens == first.final_boundary.estimated_tokens
+    assert exact.cache_creation_input_tokens_5m == 0
+
+    extended = _plan(
+        _body(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": _PREFIX}],
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "answer"}],
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "follow up", "cache_control": {"type": "ephemeral"}}],
+                },
+            ]
+        )
+    )
+    partial = await predict(cache, "scope-a", "deployment-a", extended, 102.0)
+    assert partial.state == "partial"
+    assert partial.cache_read_input_tokens == first.final_boundary.estimated_tokens
+    assert partial.cache_creation_input_tokens_5m > 0
+    assert (
+        partial.cache_read_input_tokens + partial.cache_creation_input_tokens_5m + partial.uncached_input_tokens
+        == extended.total_estimated_tokens
+    )
+
+
+@pytest.mark.asyncio
+async def test_deployment_tools_and_system_separate_observations():
+    cache = DualCache()
+    base = _plan(_body(system="stable system"))
+    await observe(cache, "scope-a", "deployment-a", base, _write_usage(base), 100.0)
+
+    assert (await predict(cache, "scope-a", "deployment-a", base, 101.0)).state == "warm"
+    assert (await predict(cache, "scope-b", "deployment-a", base, 101.0)).state == "unknown"
+    assert (await predict(cache, "scope-a", "deployment-b", base, 101.0)).state == "unknown"
+    changed_system = _plan(_body(system="different system"))
+    assert (await predict(cache, "scope-a", "deployment-a", changed_system, 101.0)).state == "unknown"
+
+    tools = [
+        {
+            "name": "weather",
+            "description": "Get weather",
+            "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}},
+        }
+    ]
+    changed_tools = _plan(_body(system="stable system", tools=tools))
+    assert (await predict(cache, "scope-a", "deployment-a", changed_tools, 101.0)).state == "unknown"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("ttl", "ttl_seconds", "write_field"),
+    (("5m", 300, "cache_creation_input_tokens_5m"), ("1h", 3600, "cache_creation_input_tokens_1h")),
+)
+async def test_ttl_controls_expiry_and_cold_budget(ttl: str, ttl_seconds: int, write_field: str):
+    cache = DualCache()
+    plan = _plan(_body(ttl=ttl))
+    cold = await predict(cache, "scope-a", "deployment", plan, 99.0)
+    assert cold.state == "unknown"
+    assert getattr(cold, write_field) == plan.final_boundary.estimated_tokens
+    assert cold.reason == "no_observation_cold_assumption"
+
+    await observe(cache, "scope-a", "deployment", plan, _write_usage(plan), 100.0)
+    live = await predict(cache, "scope-a", "deployment", plan, 100.0 + ttl_seconds - 0.1)
+    stale = await predict(cache, "scope-a", "deployment", plan, 100.0 + ttl_seconds)
+    assert live.state == "warm"
+    assert stale.state == "stale"
+    assert stale.expires_at == 100.0 + ttl_seconds
+    assert getattr(stale, write_field) == plan.final_boundary.estimated_tokens
+
+
+@pytest.mark.asyncio
+async def test_pure_read_refreshes_only_matching_exact_observation():
+    cache = DualCache()
+    plan = _plan(_body())
+    await observe(cache, "scope-a", "deployment", plan, _write_usage(plan), 100.0)
+    read_tokens = plan.final_boundary.estimated_tokens
+
+    await observe(
+        cache,
+        "scope-a",
+        "deployment",
+        plan,
+        {"cache_read_input_tokens": read_tokens, "cache_creation_input_tokens": 0},
+        200.0,
+    )
+    refreshed = await predict(cache, "scope-a", "deployment", plan, 499.0)
+    assert refreshed.state == "warm"
+    assert refreshed.as_of == 200.0
+    assert refreshed.expires_at == 500.0
+
+    await observe(
+        cache,
+        "scope-a",
+        "deployment",
+        plan,
+        {"cache_read_input_tokens": read_tokens - 1, "cache_creation_input_tokens": 0},
+        300.0,
+    )
+    unchanged = await predict(cache, "scope-a", "deployment", plan, 499.0)
+    assert unchanged.as_of == 200.0
+
+
+@pytest.mark.asyncio
+async def test_zero_failed_and_inconsistent_usage_do_not_record():
+    cache = DualCache()
+    plan = _plan(_body())
+    await observe(cache, "scope-a", "deployment", plan, {}, 100.0)
+    await observe(
+        cache,
+        "scope-a",
+        "deployment",
+        plan,
+        {"cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+        101.0,
+    )
+    await observe(
+        cache,
+        "scope-a",
+        "deployment",
+        plan,
+        {
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 10,
+            "prompt_tokens_details": {
+                "cache_write_tokens": "invalid",
+                "cache_creation_token_details": {
+                    "ephemeral_5m_input_tokens": 10,
+                    "ephemeral_1h_input_tokens": 0,
+                },
+            },
+        },
+        102.0,
+    )
+    prediction = await predict(cache, "scope-a", "deployment", plan, 103.0)
+    assert prediction.state == "unknown"
+    assert prediction.reason == "no_observation_cold_assumption"
+
+
+@pytest.mark.parametrize(
+    "update",
+    (
+        {"thinking": {"type": "adaptive"}},
+        {"context_management": {"edits": []}},
+        {"tools": [{"type": "web_search_20260209", "name": "web_search"}]},
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {"type": "url", "url": "https://example.com/image.png"},
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                }
+            ]
+        },
+    ),
+)
+def test_unsupported_transformations_media_and_server_tools_are_unknown(update: dict[str, object]):
+    assert make_plan({**_body(), **update}) is None
+
+
+def test_mixed_ttl_and_more_than_four_markers_are_unknown():
+    mixed = _body(system=[{"type": "text", "text": _PREFIX, "cache_control": {"type": "ephemeral", "ttl": "1h"}}])
+    assert make_plan(mixed) is None
+
+    messages = [
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": [{"type": "text", "text": f"{index} {_PREFIX}", "cache_control": {"type": "ephemeral"}}],
+        }
+        for index in range(5)
+    ]
+    assert make_plan(_body(messages=messages)) is None
+
+
+def test_root_automatic_cache_control_and_budget_bounds():
+    plan = _plan(_body(automatic=True))
+    assert plan.final_checkpoint_index == plan.boundaries[-1].index
+    assert plan.final_ttl_seconds == 300
+    cold = plan.cold_budget()
+    warm = plan.fully_warm_budget()
+    assert cold.cache_creation_input_tokens_5m == plan.final_boundary.estimated_tokens
+    assert warm.cache_read_input_tokens == plan.final_boundary.estimated_tokens
+    assert warm.uncached_input_tokens == cold.uncached_input_tokens
+
+
+@pytest.mark.asyncio
+async def test_ancestor_more_than_twenty_positions_back_is_not_considered():
+    cache = DualCache()
+    first = _plan(_body())
+    await observe(cache, "scope-a", "deployment", first, _write_usage(first), 100.0)
+    messages: list[dict[str, object]] = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": _PREFIX}],
+        }
+    ]
+    messages.extend(
+        {
+            "role": "assistant" if index % 2 == 0 else "user",
+            "content": [{"type": "text", "text": f"block {index}"}],
+        }
+        for index in range(20)
+    )
+    messages.append(
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "new final", "cache_control": {"type": "ephemeral"}}],
+        }
+    )
+    far = _plan(_body(messages=messages))
+    prediction = await predict(cache, "scope-a", "deployment", far, 101.0)
+    assert prediction.state == "unknown"
+    assert prediction.reason == "no_observation_cold_assumption"

--- a/tests/test_litellm/proxy/management_endpoints/test_cache_switch_cost_estimate_endpoint.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_cache_switch_cost_estimate_endpoint.py
@@ -1,0 +1,396 @@
+"""Tests for the /cost/estimate/cache-switch endpoint."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import litellm
+from litellm.proxy._types import (
+    CacheSwitchCostEstimateArmRequest,
+    CacheSwitchCostEstimateRequest,
+    CacheSwitchPredictionRequest,
+)
+from litellm.proxy.management_endpoints.cache_switch_cost_estimate import (
+    estimate_cache_switch_cost,
+    predict_cache_switch_cost,
+)
+from litellm.litellm_core_utils.prompt_cache_prediction import make_plan, observe
+
+
+class TestCacheSwitchCostEstimateEndpoint:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("missing_field", "request_overrides", "expected_label"),
+        (
+            (
+                "cache_read_input_token_cost",
+                {"cache_read_input_tokens": 1},
+                "cache read",
+            ),
+            (
+                "cache_creation_input_token_cost",
+                {"cache_creation_input_tokens_5m": 1},
+                "5-minute cache write",
+            ),
+            (
+                "cache_creation_input_token_cost_above_1hr",
+                {"cache_creation_input_tokens_1h": 1},
+                "1-hour cache write",
+            ),
+        ),
+    )
+    async def test_rejects_nonzero_cache_bucket_without_its_rate(
+        self, monkeypatch, missing_field, request_overrides, expected_label
+    ):
+        model = "openai/cache-rate-gap"
+        pricing = {
+            "input_cost_per_token": 1e-6,
+            "output_cost_per_token": 2e-6,
+            "cache_read_input_token_cost": 0.1e-6,
+            "cache_creation_input_token_cost": 1.25e-6,
+            "cache_creation_input_token_cost_above_1hr": 2e-6,
+            "litellm_provider": "openai",
+            "mode": "chat",
+        }
+        pricing.pop(missing_field)
+        monkeypatch.setitem(litellm.model_cost, model, pricing)
+        arm = CacheSwitchCostEstimateArmRequest(
+            model=model,
+            uncached_input_tokens=0,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens_5m=0,
+            cache_creation_input_tokens_1h=0,
+        ).model_copy(update=request_overrides)
+
+        with patch(  # test-quality-ok: inject router singleton to exercise the public endpoint
+            "litellm.proxy.proxy_server.llm_router", None
+        ):  # test-quality-ok: proxy router is the endpoint dependency injection seam
+            from fastapi import HTTPException
+
+            with pytest.raises(HTTPException, match=expected_label) as exc_info:
+                await estimate_cache_switch_cost(
+                    request=CacheSwitchCostEstimateRequest(stay=arm, switch=arm),
+                    user_api_key_dict=MagicMock(),
+                )
+
+        assert exc_info.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_prices_warm_stay_against_cold_switch_with_ttl_split(self, monkeypatch):
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "anthropic/stay-model",
+            {
+                "input_cost_per_token": 5e-6,
+                "output_cost_per_token": 25e-6,
+                "cache_read_input_token_cost": 0.5e-6,
+                "cache_creation_input_token_cost": 6.25e-6,
+                "cache_creation_input_token_cost_above_1hr": 10e-6,
+                "litellm_provider": "anthropic",
+                "mode": "chat",
+            },
+        )
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "anthropic/switch-model",
+            {
+                "input_cost_per_token": 1e-6,
+                "output_cost_per_token": 5e-6,
+                "cache_read_input_token_cost": 0.1e-6,
+                "cache_creation_input_token_cost": 1.25e-6,
+                "cache_creation_input_token_cost_above_1hr": 2e-6,
+                "litellm_provider": "anthropic",
+                "mode": "chat",
+            },
+        )
+        request = CacheSwitchCostEstimateRequest(
+            stay=CacheSwitchCostEstimateArmRequest(
+                model="anthropic/stay-model",
+                uncached_input_tokens=0,
+                cache_read_input_tokens=100_000,
+                cache_creation_input_tokens_5m=2_000,
+                cache_creation_input_tokens_1h=0,
+                assumed_cache_state="warm",
+            ),
+            switch=CacheSwitchCostEstimateArmRequest(
+                model="anthropic/switch-model",
+                uncached_input_tokens=0,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens_5m=42_000,
+                cache_creation_input_tokens_1h=60_000,
+                assumed_cache_state="cold",
+            ),
+        )
+
+        with patch(  # test-quality-ok: inject router singleton to exercise the public endpoint
+            "litellm.proxy.proxy_server.llm_router", None
+        ):  # test-quality-ok: proxy router is the endpoint dependency injection seam
+            response = await estimate_cache_switch_cost(request=request, user_api_key_dict=MagicMock())
+
+        assert response.stay.input_cost == pytest.approx(0.0625)
+        assert response.switch.cache_creation_input_cost_5m == pytest.approx(0.0525)
+        assert response.switch.cache_creation_input_cost_1h == pytest.approx(0.12)
+        assert response.switch.input_cost == pytest.approx(0.1725)
+        assert response.switch_cost_delta == pytest.approx(0.11)
+        assert response.stay.assumed_cache_state == "warm"
+        assert response.switch.assumed_cache_state == "cold"
+
+    @pytest.mark.asyncio
+    async def test_rejects_ambiguous_model_group_without_model_id(self):
+        mock_router = MagicMock()
+        mock_router.get_model_list.return_value = [
+            {"model_info": {"id": "one"}, "litellm_params": {"model": "openai/gpt-4o"}},
+            {"model_info": {"id": "two"}, "litellm_params": {"model": "openai/gpt-4o-mini"}},
+        ]
+        arm = CacheSwitchCostEstimateArmRequest(
+            model="ambiguous-group",
+            uncached_input_tokens=1,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens_5m=0,
+            cache_creation_input_tokens_1h=0,
+        )
+
+        with patch(  # test-quality-ok: inject router singleton to exercise the public endpoint
+            "litellm.proxy.proxy_server.llm_router", mock_router
+        ):  # test-quality-ok: proxy router is the endpoint dependency injection seam
+            from fastapi import HTTPException
+
+            with pytest.raises(HTTPException, match="multiple deployments") as exc_info:
+                await estimate_cache_switch_cost(
+                    request=CacheSwitchCostEstimateRequest(stay=arm, switch=arm),
+                    user_api_key_dict=MagicMock(),
+                )
+
+        assert exc_info.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_model_id_must_belong_to_the_named_group(self):
+        mock_router = MagicMock()
+        mock_router.get_model_list.return_value = [
+            {"model_info": {"id": "one"}, "litellm_params": {"model": "openai/gpt-4o"}}
+        ]
+        arm = CacheSwitchCostEstimateArmRequest(
+            model="group",
+            model_id="other",
+            uncached_input_tokens=1,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens_5m=0,
+            cache_creation_input_tokens_1h=0,
+        )
+
+        with patch(  # test-quality-ok: inject router singleton to exercise the public endpoint
+            "litellm.proxy.proxy_server.llm_router", mock_router
+        ):  # test-quality-ok: proxy router is the endpoint dependency injection seam
+            from fastapi import HTTPException
+
+            with pytest.raises(HTTPException, match="does not uniquely identify") as exc_info:
+                await estimate_cache_switch_cost(
+                    request=CacheSwitchCostEstimateRequest(stay=arm, switch=arm),
+                    user_api_key_dict=MagicMock(),
+                )
+
+        assert exc_info.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_same_model_and_buckets_cost_the_same_for_every_cache_state_label(self, monkeypatch):
+        model = "anthropic/state-label-model"
+        monkeypatch.setitem(
+            litellm.model_cost,
+            model,
+            {
+                "input_cost_per_token": 1e-6,
+                "output_cost_per_token": 5e-6,
+                "cache_read_input_token_cost": 0.1e-6,
+                "cache_creation_input_token_cost": 1.25e-6,
+                "cache_creation_input_token_cost_above_1hr": 2e-6,
+                "litellm_provider": "anthropic",
+                "mode": "chat",
+            },
+        )
+        base = CacheSwitchCostEstimateArmRequest(
+            model=model,
+            uncached_input_tokens=100,
+            cache_read_input_tokens=800,
+            cache_creation_input_tokens_5m=50,
+            cache_creation_input_tokens_1h=50,
+            assumed_cache_state="warm",
+        )
+
+        with patch(  # test-quality-ok: inject router singleton to exercise the public endpoint
+            "litellm.proxy.proxy_server.llm_router", None
+        ):  # test-quality-ok: proxy router is the endpoint dependency injection seam
+            response = await estimate_cache_switch_cost(
+                request=CacheSwitchCostEstimateRequest(
+                    stay=base,
+                    switch=base.model_copy(update={"assumed_cache_state": "stale"}),
+                ),
+                user_api_key_dict=MagicMock(),
+            )
+
+        assert response.stay.input_cost == response.switch.input_cost
+        assert response.switch_cost_delta == 0.0
+
+    @pytest.mark.asyncio
+    async def test_model_id_prices_the_selected_deployment(self):
+        mock_router = MagicMock()
+        deployments = [
+            {
+                "model_info": {"id": "expensive"},
+                "litellm_params": {
+                    "model": "custom/model",
+                    "custom_llm_provider": "openai",
+                    "input_cost_per_token": 2e-6,
+                    "output_cost_per_token": 0.0,
+                },
+            },
+            {
+                "model_info": {"id": "cheap"},
+                "litellm_params": {
+                    "model": "custom/model",
+                    "custom_llm_provider": "openai",
+                    "input_cost_per_token": 1e-6,
+                    "output_cost_per_token": 0.0,
+                },
+            },
+        ]
+        mock_router.get_model_list.return_value = deployments
+        mock_router.get_deployment_model_info.side_effect = lambda model_id, model_name: {
+            "input_cost_per_token": 2e-6 if model_id == "expensive" else 1e-6,
+            "output_cost_per_token": 0.0,
+            "cache_read_input_token_cost": 2e-6 if model_id == "expensive" else 1e-6,
+            "cache_creation_input_token_cost": 2e-6 if model_id == "expensive" else 1e-6,
+            "litellm_provider": "openai",
+            "mode": "chat",
+        }
+        stay = CacheSwitchCostEstimateArmRequest(
+            model="pool",
+            model_id="expensive",
+            uncached_input_tokens=1_000,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens_5m=0,
+            cache_creation_input_tokens_1h=0,
+        )
+        switch = stay.model_copy(update={"model_id": "cheap"})
+
+        with patch(  # test-quality-ok: inject router singleton to exercise the public endpoint
+            "litellm.proxy.proxy_server.llm_router", mock_router
+        ):  # test-quality-ok: proxy router is the endpoint dependency injection seam
+            response = await estimate_cache_switch_cost(
+                request=CacheSwitchCostEstimateRequest(stay=stay, switch=switch),
+                user_api_key_dict=MagicMock(),
+            )
+
+        assert response.stay.resolved_model_id == "expensive"
+        assert response.switch.resolved_model_id == "cheap"
+        assert response.stay.input_cost == pytest.approx(0.002)
+        assert response.switch.input_cost == pytest.approx(0.001)
+        assert response.switch_cost_delta == pytest.approx(-0.001)
+
+    def test_http_route_returns_the_signed_comparison(self):
+        from fastapi.testclient import TestClient
+
+        from litellm.proxy.proxy_server import app
+
+        with patch(  # test-quality-ok: inject router singleton to exercise the public endpoint
+            "litellm.proxy.proxy_server.llm_router", None
+        ):  # test-quality-ok: proxy router is the endpoint dependency injection seam
+            response = TestClient(app).post(
+                "/cost/estimate/cache-switch",
+                headers={"Authorization": "Bearer sk-1234"},
+                json={
+                    "stay": {
+                        "model": "anthropic/claude-opus-4-8",
+                        "uncached_input_tokens": 0,
+                        "cache_read_input_tokens": 100_000,
+                        "cache_creation_input_tokens_5m": 2_000,
+                        "cache_creation_input_tokens_1h": 0,
+                    },
+                    "switch": {
+                        "model": "anthropic/claude-haiku-4-5",
+                        "uncached_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens_5m": 102_000,
+                        "cache_creation_input_tokens_1h": 0,
+                    },
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["stay"]["input_cost"] == pytest.approx(0.0625)
+        assert response.json()["switch"]["input_cost"] == pytest.approx(0.1275)
+        assert response.json()["switch_cost_delta"] == pytest.approx(0.065)
+
+    @pytest.mark.asyncio
+    async def test_predict_uses_scoped_observed_cache_instead_of_caller_buckets(self):
+        from datetime import datetime, timezone
+        from litellm._internal_context import pinned_billing_time
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm import Router
+
+        now = datetime(2026, 9, 12, tzinfo=timezone.utc)
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "source",
+                    "litellm_params": {"model": "anthropic/claude-opus-4-8", "api_key": "test"},
+                    "model_info": {"id": "source-id"},
+                },
+                {
+                    "model_name": "target",
+                    "litellm_params": {"model": "anthropic/claude-haiku-4-5", "api_key": "test"},
+                    "model_info": {"id": "target-id"},
+                },
+            ]
+        )
+        prompt = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "stable prefix " * 3000, "cache_control": {"type": "ephemeral"}}
+                    ],
+                }
+            ]
+        }
+        request = CacheSwitchPredictionRequest.model_validate(
+            {
+                "stay": {"model": "source", "prompt": prompt},
+                "switch": {"model": "target", "prompt": prompt},
+            }
+        )
+        plan = make_plan({**prompt, "model": "claude-opus-4-8"})
+        assert plan is not None
+        provider_tokens = plan.final_boundary.estimated_tokens
+        await observe(
+            router.cache,
+            "caller-hash",
+            "source-id",
+            plan,
+            {
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": provider_tokens,
+                "prompt_tokens_details": {
+                    "cache_creation_tokens": provider_tokens,
+                    "cache_creation_token_details": {
+                        "ephemeral_5m_input_tokens": provider_tokens,
+                        "ephemeral_1h_input_tokens": 0,
+                    },
+                },
+            },
+            now.timestamp() - 1,
+        )
+        with patch(  # test-quality-ok: inject router singleton to exercise the public endpoint
+            "litellm.proxy.proxy_server.llm_router", router
+        ):  # test-quality-ok: inject real Router into proxy singleton
+            with pinned_billing_time(now):
+                response = await predict_cache_switch_cost(request, UserAPIKeyAuth(api_key="caller-hash"))
+                other = await predict_cache_switch_cost(request, UserAPIKeyAuth(api_key="other-hash"))
+        assert response.stay.cache_state == "warm"
+        assert response.stay.cache_read_input_tokens == provider_tokens
+        assert response.stay.cache_creation_input_tokens_5m == 0
+        assert response.stay.estimated_input_cost is not None
+        assert response.switch.cache_state == "unknown"
+        assert response.switch.estimated_input_cost is None
+        assert response.switch.cold_input_cost > response.switch.warm_input_cost
+        assert response.switch_cost_delta is None
+        assert other.stay.cache_state == "unknown"

--- a/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
+++ b/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
@@ -582,8 +582,8 @@ def test_cost_tracking_adds_db_and_shadow_eval_callbacks_when_prisma_set(monkeyp
         "prisma_was_set": True,
     }
     assert normalize(observed) == {
-        "added_to_callbacks": 2,
-        "added_to_async_success": 1,
+        "added_to_callbacks": 3,
+        "added_to_async_success": 2,
         "shadow_eval_loggers": 1,
         "prisma_was_set": True,
     }

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -3379,6 +3379,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/cost/estimate/cache-switch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Estimate Cache Switch Cost */
+        post: operations["estimate_cache_switch_cost_cost_estimate_cache_switch_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/cost/estimate/cache-switch/predict": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Predict Cache Switch Cost */
+        post: operations["predict_cache_switch_cost_cost_estimate_cache_switch_predict_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/credentials": {
         parameters: {
             query?: never;
@@ -24678,6 +24712,207 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /** CacheSwitchCostEstimateArmRequest */
+        CacheSwitchCostEstimateArmRequest: {
+            /**
+             * Assumed Cache State
+             * @description Descriptive assumption only; token buckets determine the estimate
+             */
+            assumed_cache_state?: ("warm" | "cold" | "stale" | "unknown") | null;
+            /**
+             * Cache Creation Input Tokens 1H
+             * @description Input tokens assumed to write a 1-hour cache
+             */
+            cache_creation_input_tokens_1h: number;
+            /**
+             * Cache Creation Input Tokens 5M
+             * @description Input tokens assumed to write a 5-minute cache
+             */
+            cache_creation_input_tokens_5m: number;
+            /**
+             * Cache Read Input Tokens
+             * @description Input tokens assumed to hit the prompt cache
+             */
+            cache_read_input_tokens: number;
+            /**
+             * Model
+             * @description Provider-qualified model or configured model group
+             */
+            model: string;
+            /**
+             * Model Id
+             * @description Required when model resolves to multiple deployments
+             */
+            model_id?: string | null;
+            /**
+             * Uncached Input Tokens
+             * @description Input tokens billed at the normal input rate
+             */
+            uncached_input_tokens: number;
+        };
+        /** CacheSwitchCostEstimateArmResponse */
+        CacheSwitchCostEstimateArmResponse: {
+            /**
+             * Assumed Cache State
+             * @description Descriptive assumption only; token buckets determine the estimate
+             */
+            assumed_cache_state?: ("warm" | "cold" | "stale" | "unknown") | null;
+            /** Cache Creation Input Cost 1H */
+            cache_creation_input_cost_1h: number;
+            /** Cache Creation Input Cost 5M */
+            cache_creation_input_cost_5m: number;
+            /** Cache Creation Input Token Cost 1H */
+            cache_creation_input_token_cost_1h: number;
+            /** Cache Creation Input Token Cost 5M */
+            cache_creation_input_token_cost_5m: number;
+            /**
+             * Cache Creation Input Tokens 1H
+             * @description Input tokens assumed to write a 1-hour cache
+             */
+            cache_creation_input_tokens_1h: number;
+            /**
+             * Cache Creation Input Tokens 5M
+             * @description Input tokens assumed to write a 5-minute cache
+             */
+            cache_creation_input_tokens_5m: number;
+            /** Cache Read Input Cost */
+            cache_read_input_cost: number;
+            /** Cache Read Input Token Cost */
+            cache_read_input_token_cost: number;
+            /**
+             * Cache Read Input Tokens
+             * @description Input tokens assumed to hit the prompt cache
+             */
+            cache_read_input_tokens: number;
+            /**
+             * Input Cost
+             * @description Estimated input cost in USD
+             */
+            input_cost: number;
+            /** Input Cost Per Token */
+            input_cost_per_token: number;
+            /** Input Tokens */
+            input_tokens: number;
+            /**
+             * Model
+             * @description Provider-qualified model or configured model group
+             */
+            model: string;
+            /**
+             * Model Id
+             * @description Required when model resolves to multiple deployments
+             */
+            model_id?: string | null;
+            /** Provider */
+            provider: string | null;
+            /** Resolved Model */
+            resolved_model: string;
+            /** Resolved Model Id */
+            resolved_model_id: string | null;
+            /** Uncached Input Cost */
+            uncached_input_cost: number;
+            /**
+             * Uncached Input Tokens
+             * @description Input tokens billed at the normal input rate
+             */
+            uncached_input_tokens: number;
+        };
+        /** CacheSwitchCostEstimateRequest */
+        CacheSwitchCostEstimateRequest: {
+            stay: components["schemas"]["CacheSwitchCostEstimateArmRequest"];
+            switch: components["schemas"]["CacheSwitchCostEstimateArmRequest"];
+        };
+        /** CacheSwitchCostEstimateResponse */
+        CacheSwitchCostEstimateResponse: {
+            stay: components["schemas"]["CacheSwitchCostEstimateArmResponse"];
+            switch: components["schemas"]["CacheSwitchCostEstimateArmResponse"];
+            /**
+             * Switch Cost Delta
+             * @description Switch input cost minus stay input cost in USD
+             */
+            switch_cost_delta: number;
+        };
+        /** CacheSwitchPredictionArm */
+        CacheSwitchPredictionArm: {
+            /** Cache Creation Input Tokens 1H */
+            cache_creation_input_tokens_1h?: number | null;
+            /** Cache Creation Input Tokens 5M */
+            cache_creation_input_tokens_5m?: number | null;
+            /**
+             * Cache Penalty
+             * @description Estimated input cost minus this model's fully warm input cost
+             */
+            cache_penalty?: number | null;
+            /** Cache Read Input Tokens */
+            cache_read_input_tokens?: number | null;
+            /**
+             * Cache State
+             * @enum {string}
+             */
+            cache_state: "warm" | "partial" | "stale" | "unknown" | "disabled";
+            /** Cold Input Cost */
+            cold_input_cost?: number | null;
+            /**
+             * Estimated Input Cost
+             * @description USD; null when cache evidence is unavailable
+             */
+            estimated_input_cost?: number | null;
+            /** Expires At */
+            expires_at?: number | null;
+            /** Model */
+            model: string;
+            /** Model Id */
+            model_id: string | null;
+            /** Observed At */
+            observed_at?: number | null;
+            /** Reason */
+            reason: string;
+            /** Uncached Input Tokens */
+            uncached_input_tokens?: number | null;
+            /** Warm Input Cost */
+            warm_input_cost?: number | null;
+        };
+        /** CacheSwitchPredictionRequest */
+        CacheSwitchPredictionRequest: {
+            stay: components["schemas"]["CacheSwitchPredictionTarget"];
+            switch: components["schemas"]["CacheSwitchPredictionTarget"];
+        };
+        /** CacheSwitchPredictionResponse */
+        CacheSwitchPredictionResponse: {
+            /**
+             * Cache Evidence Source
+             * @default gateway_observations
+             * @constant
+             */
+            cache_evidence_source: "gateway_observations";
+            stay: components["schemas"]["CacheSwitchPredictionArm"];
+            switch: components["schemas"]["CacheSwitchPredictionArm"];
+            /**
+             * Switch Cost Delta
+             * @description Switch minus stay input cost in USD; null if either state is unknown
+             */
+            switch_cost_delta: number | null;
+            /**
+             * Token Count Source
+             * @default local_estimate_with_observed_prefix
+             * @constant
+             */
+            token_count_source: "local_estimate_with_observed_prefix";
+        };
+        /** CacheSwitchPredictionTarget */
+        CacheSwitchPredictionTarget: {
+            /** Model */
+            model: string;
+            /** Model Id */
+            model_id?: string | null;
+            /**
+             * Prompt
+             * @description Native Anthropic Messages body, excluding model and credentials
+             */
+            prompt: {
+                [key: string]: unknown;
+            };
+        };
         /** CacheTestRequest */
         CacheTestRequest: {
             /**
@@ -45111,6 +45346,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CostEstimateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    estimate_cache_switch_cost_cost_estimate_cache_switch_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CacheSwitchCostEstimateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CacheSwitchCostEstimateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    predict_cache_switch_cost_cost_estimate_cache_switch_predict_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CacheSwitchPredictionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CacheSwitchPredictionResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Model switches can rebuild prompt caches unexpectedly
- A cheaper model may cost more while its cache is cold
- Cache state cannot be read directly from providers before a request

How it solves it:

- Records confirmed Anthropic cache activity after successful requests
- Fingerprints native cacheable prefixes without storing prompt text
- Predicts warm, partial, stale, unknown, or below-minimum states
- Prices observed, cold, and warm scenarios through shared billing rates

## User Flow

Before: an operator gets a manually supplied cache-cost comparison

1. They send POST http://localhost:47612/cost/estimate/cache-switch with assumed token buckets
2. The proxy returns a signed price difference, but does not know whether either cache is warm
3. A cache-state label is only caller-provided metadata

After: the operator can ask for an observation-backed estimate

1. They send POST http://localhost:47612/cost/estimate/cache-switch/predict with native prompt bodies for stay and switch targets
2. The proxy checks confirmed cache observations scoped to the authenticated caller and concrete deployment
3. It returns each target's state, evidence timestamp, expiry, warm and cold costs, derived token buckets, cache penalty, and signed switch delta
4. After a successful provider request reports cache-write or cache-read tokens, repeating the same request returns `warm` for that deployment when the observation is still live

## Relevant issues

- Adds an observation-backed prompt-cache switch estimator
- Keeps inferred state out of routing policy in this version

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required local lint, type, and schema checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

The predictor proof used an isolated Postgres database, a native Anthropic body, and the real gateway target

### Before (22c60ef9e7)

1. `POST http://localhost:47612/cost/estimate/cache-switch/predict` with stay and switch prompt bodies
2. Observed: the route did not exist
3. The old `/cost/estimate/cache-switch` route only priced caller-supplied buckets and had no provider observation state

### After (f7aecc3354)

1. Before the first provider request, `POST /cost/estimate/cache-switch/predict` returned `stay.cache_state: "unknown"` and `switch.cache_state: "unknown"`
2. The same native prompt was sent through `POST /v1/messages` to the real gateway target
3. The provider response reported `cache_creation_input_tokens: 14020` and `ephemeral_5m_input_tokens: 14020`
4. The next prediction returned `stay.cache_state: "warm"`, `stay.cache_read_input_tokens: 14020`, `stay.estimated_input_cost: 0.002804`, and `stay.cache_penalty: 0.000589`
5. The unobserved switch target remained `unknown` with a cold scenario of `$0.0088875`; no false switch delta was emitted
6. A second real target request produced `warm` for both deployments; extending the prompt produced `partial` with the observed prefix as reads and the new suffix as writes

## Type

New Feature

## Caveats (if any)

### Medium

- Provider cache state remains opaque; warm means recent gateway observation
- Unsupported transforms, multiple breakpoints, missing telemetry, and callback races return unknown
- Predictor does not change model or tier routing in this PR
- Native Anthropic request plans are bounded to two megabytes and 4,096 segments

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
