### PR TITLE
fix(mcp): match per-server OAuth metadata issuers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -2490,11 +2490,7 @@ async def _build_oauth_protected_resource_response(
 
     return {
         "authorization_servers": [
-            resource_url
-            if explicitly_named
-            else f"{request_base_url}/{mcp_server_name}"
-            if mcp_server_name
-            else request_base_url
+            (f"{request_base_url}/{mcp_server_name}" if mcp_server_name else f"{request_base_url}")
         ],
         "resource": resource_url,
         "scopes_supported": (mcp_server.scopes if mcp_server and mcp_server.scopes else []),

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -2490,7 +2490,11 @@ async def _build_oauth_protected_resource_response(
 
     return {
         "authorization_servers": [
-            (f"{request_base_url}/{mcp_server_name}" if mcp_server_name else f"{request_base_url}")
+            resource_url
+            if explicitly_named
+            else f"{request_base_url}/{mcp_server_name}"
+            if mcp_server_name
+            else request_base_url
         ],
         "resource": resource_url,
         "scopes_supported": (mcp_server.scopes if mcp_server and mcp_server.scopes else []),
@@ -2666,6 +2670,8 @@ async def oauth_protected_resource_mcp(request: Request, mcp_server_name: str | 
 def _build_oauth_authorization_server_response(
     request: Request,
     mcp_server_name: str | None,
+    *,
+    issuer_path: str | None = None,
 ) -> dict:
     """Build OAuth authorization server metadata response (gateway-as-AS shape).
 
@@ -2694,7 +2700,13 @@ def _build_oauth_authorization_server_response(
 
     _raise_unless_oauth2_discovery_server(mcp_server, mcp_server_name, "not an OAuth authorization server")
 
-    issuer: Final = f"{request_base_url}/{mcp_server_name}" if explicitly_named else request_base_url
+    issuer: Final = (
+        f"{request_base_url}/{issuer_path}"
+        if issuer_path is not None
+        else f"{request_base_url}/{mcp_server_name}"
+        if explicitly_named
+        else request_base_url
+    )
 
     return {
         "issuer": issuer,
@@ -2724,6 +2736,7 @@ async def oauth_authorization_server_mcp_standard(request: Request, mcp_server_n
     return _build_oauth_authorization_server_response(
         request=request,
         mcp_server_name=mcp_server_name,
+        issuer_path=f"mcp/{mcp_server_name}",
     )
 
 
@@ -2802,7 +2815,7 @@ async def jwks_json(request: Request):
 
 
 # Additional legacy pattern support
-@router.get("/.well-known/oauth-authorization-server/{mcp_server_name}/mcp")
+@router.get(f"/.well-known/oauth-authorization-server{well_known_root_suffix()}/{{mcp_server_name}}/mcp")
 async def oauth_authorization_server_legacy(request: Request, mcp_server_name: str):
     """
     OAuth authorization server discovery for legacy /{server_name}/mcp pattern.
@@ -2810,6 +2823,7 @@ async def oauth_authorization_server_legacy(request: Request, mcp_server_name: s
     return _build_oauth_authorization_server_response(
         request=request,
         mcp_server_name=mcp_server_name,
+        issuer_path=f"{mcp_server_name}/mcp",
     )
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -11234,3 +11234,50 @@ def test_named_resource_discovery_follows_matching_authorization_issuer(
     authorization = client.get(f"{prefix}/.well-known/oauth-authorization-server/{issuer_path}")
     assert authorization.status_code == 200
     assert authorization.json()["issuer"] == resource["authorization_servers"][0]
+
+
+def test_static_root_path_authorization_discovery_preserves_issuer(monkeypatch):
+    import subprocess
+    import sys
+
+    monkeypatch.setenv("SERVER_ROOT_PATH", "/gateway")
+    monkeypatch.setenv("PROXY_BASE_URL", "http://testserver/gateway")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import json
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from litellm.proxy._experimental.mcp_server.discoverable_endpoints import router
+from litellm.proxy._experimental.mcp_server.mcp_server_manager import global_mcp_server_manager
+from litellm.types.mcp import MCPAuth, MCPTransport
+from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+global_mcp_server_manager.registry['example'] = MCPServer(
+    server_id='example', name='example', server_name='example', alias='example',
+    transport=MCPTransport.http, auth_type=MCPAuth.oauth2,
+    authorization_url='https://idp.example.com/authorize', token_url='https://idp.example.com/token',
+)
+app = FastAPI(root_path='/gateway')
+app.include_router(router)
+with TestClient(app) as client:
+    responses = {
+        path: client.get('/.well-known/oauth-authorization-server/gateway/' + path)
+        for path in ('mcp/example', 'example/mcp', 'example', 'mcp')
+    }
+    print(json.dumps({path: {'status': response.status_code, 'body': response.json()}
+                      for path, response in responses.items()}))
+""",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    responses = json.loads(result.stdout)
+    for path in ("mcp/example", "example/mcp", "example", "mcp"):
+        assert responses[path]["status"] == 200, responses[path]
+        assert responses[path]["body"]["issuer"] == f"http://testserver/gateway/{path}"
+    assert responses["example/mcp"]["body"]["token_endpoint"] == "http://testserver/gateway/example/token"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -3419,16 +3419,16 @@ async def test_oauth_protected_resource_gateway_managed_oauth2_advertises_gatewa
         relay_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name="relay_mcp", use_standard_pattern=True
         )
-        assert relay_response["authorization_servers"] == ["https://litellm.example.com/relay_mcp"]
+        assert relay_response["authorization_servers"] == ["https://litellm.example.com/mcp/relay_mcp"]
         relay_legacy_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name="relay_mcp", use_standard_pattern=False
         )
-        assert relay_legacy_response["authorization_servers"] == ["https://litellm.example.com/relay_mcp"]
+        assert relay_legacy_response["authorization_servers"] == ["https://litellm.example.com/relay_mcp/mcp"]
 
         delegated_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name="delegated_mcp", use_standard_pattern=True
         )
-        assert delegated_response["authorization_servers"] == ["https://litellm.example.com/delegated_mcp"]
+        assert delegated_response["authorization_servers"] == ["https://litellm.example.com/mcp/delegated_mcp"]
     finally:
         global_mcp_server_manager.registry.clear()
 
@@ -9120,8 +9120,8 @@ async def test_named_discovery_issuer_matches_protected_resource_authorization_s
     from fastapi import Request
 
     from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
-        _build_oauth_authorization_server_response,
         _build_oauth_protected_resource_response,
+        oauth_authorization_server_mcp_standard,
     )
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
         global_mcp_server_manager,
@@ -9139,10 +9139,10 @@ async def test_named_discovery_issuer_matches_protected_resource_authorization_s
         resource_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name="test_oauth", use_standard_pattern=True
         )
-        authorization_response = _build_oauth_authorization_server_response(
+        authorization_response = await oauth_authorization_server_mcp_standard(
             request=mock_request, mcp_server_name="test_oauth"
         )
-        assert resource_response["authorization_servers"] == ["https://llm.example.com/test_oauth"]
+        assert resource_response["authorization_servers"] == ["https://llm.example.com/mcp/test_oauth"]
         assert authorization_response["issuer"] == resource_response["authorization_servers"][0]
     finally:
         global_mcp_server_manager.registry.clear()
@@ -11186,3 +11186,51 @@ async def test_dcr_refusal_is_actionable_without_upstream_body(
     assert f"HTTP {upstream_status}" in str(exc.value.detail)
     assert "pre-registered OAuth client" in str(exc.value.detail)
     assert "private upstream details" not in str(exc.value.detail)
+
+
+@pytest.mark.parametrize("prefix", ["", "/tenant-a", "/tenant-b"])
+@pytest.mark.parametrize(
+    ("server_name", "pattern"),
+    [
+        ("issuer_test", "mcp/{server}"),
+        ("issuer_test", "{server}/mcp"),
+        ("issuer_test", "{server}"),
+        ("mcp", "mcp/{server}"),
+        ("mcp", "{server}/mcp"),
+    ],
+)
+def test_per_server_authorization_metadata_issuer_matches_discovery_path(
+    _no_proxy_base_url, _isolated_mcp_registry, prefix, server_name, pattern
+):
+    server = _create_oauth2_server(server_id=server_name, name=server_name, server_name=server_name, alias=server_name)
+    _isolated_mcp_registry[server.server_id] = server
+    client = _prefixed_discovery_client(["/tenant-a", "/tenant-b"])
+    path = pattern.format(server=server_name)
+    response = client.get(f"{prefix}/.well-known/oauth-authorization-server/{path}")
+    assert response.status_code == 200
+    metadata = response.json()
+    assert metadata["issuer"] == f"http://testserver{prefix}/{path}"
+    assert metadata["authorization_endpoint"] == f"http://testserver{prefix}/{server_name}/authorize"
+    assert metadata["token_endpoint"] == f"http://testserver{prefix}/{server_name}/token"
+    assert metadata["registration_endpoint"] == f"http://testserver{prefix}/{server_name}/register"
+
+
+@pytest.mark.parametrize("prefix", ["", "/tenant-a"])
+@pytest.mark.parametrize("relay", [False, True])
+@pytest.mark.parametrize("pattern", ["mcp/{server}", "{server}/mcp"])
+def test_named_resource_discovery_follows_matching_authorization_issuer(
+    _no_proxy_base_url, _isolated_mcp_registry, prefix, relay, pattern
+):
+    server = _create_oauth2_server().model_copy(update={"per_server_oauth_discovery": relay})
+    _isolated_mcp_registry[server.server_id] = server
+    client = _prefixed_discovery_client(["/tenant-a"])
+    path = pattern.format(server=server.server_name)
+    response = client.get(f"{prefix}/.well-known/oauth-protected-resource/{path}")
+    assert response.status_code == 200
+    resource = response.json()
+    issuer_path = path if relay else "mcp"
+    assert resource["resource"] == f"http://testserver{prefix}/{path}"
+    assert resource["authorization_servers"] == [f"http://testserver{prefix}/{issuer_path}"]
+    authorization = client.get(f"{prefix}/.well-known/oauth-authorization-server/{issuer_path}")
+    assert authorization.status_code == 200
+    assert authorization.json()["issuer"] == resource["authorization_servers"][0]

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -11236,12 +11236,13 @@ def test_named_resource_discovery_follows_matching_authorization_issuer(
     assert authorization.json()["issuer"] == resource["authorization_servers"][0]
 
 
-def test_static_root_path_authorization_discovery_preserves_issuer(monkeypatch):
+def test_static_root_path_authorization_discovery_preserves_issuer(monkeypatch, tmp_path):
     import subprocess
     import sys
 
     monkeypatch.setenv("SERVER_ROOT_PATH", "/gateway")
     monkeypatch.setenv("PROXY_BASE_URL", "http://testserver/gateway")
+    monkeypatch.setenv("LITELLM_UI_PATH", str(tmp_path / "ui"))
     result = subprocess.run(
         [
             sys.executable,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -3419,16 +3419,16 @@ async def test_oauth_protected_resource_gateway_managed_oauth2_advertises_gatewa
         relay_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name="relay_mcp", use_standard_pattern=True
         )
-        assert relay_response["authorization_servers"] == ["https://litellm.example.com/mcp/relay_mcp"]
+        assert relay_response["authorization_servers"] == ["https://litellm.example.com/relay_mcp"]
         relay_legacy_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name="relay_mcp", use_standard_pattern=False
         )
-        assert relay_legacy_response["authorization_servers"] == ["https://litellm.example.com/relay_mcp/mcp"]
+        assert relay_legacy_response["authorization_servers"] == ["https://litellm.example.com/relay_mcp"]
 
         delegated_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name="delegated_mcp", use_standard_pattern=True
         )
-        assert delegated_response["authorization_servers"] == ["https://litellm.example.com/mcp/delegated_mcp"]
+        assert delegated_response["authorization_servers"] == ["https://litellm.example.com/delegated_mcp"]
     finally:
         global_mcp_server_manager.registry.clear()
 
@@ -9120,8 +9120,8 @@ async def test_named_discovery_issuer_matches_protected_resource_authorization_s
     from fastapi import Request
 
     from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _build_oauth_authorization_server_response,
         _build_oauth_protected_resource_response,
-        oauth_authorization_server_mcp_standard,
     )
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
         global_mcp_server_manager,
@@ -9139,10 +9139,10 @@ async def test_named_discovery_issuer_matches_protected_resource_authorization_s
         resource_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name="test_oauth", use_standard_pattern=True
         )
-        authorization_response = await oauth_authorization_server_mcp_standard(
+        authorization_response = _build_oauth_authorization_server_response(
             request=mock_request, mcp_server_name="test_oauth"
         )
-        assert resource_response["authorization_servers"] == ["https://llm.example.com/mcp/test_oauth"]
+        assert resource_response["authorization_servers"] == ["https://llm.example.com/test_oauth"]
         assert authorization_response["issuer"] == resource_response["authorization_servers"][0]
     finally:
         global_mcp_server_manager.registry.clear()
@@ -11228,7 +11228,7 @@ def test_named_resource_discovery_follows_matching_authorization_issuer(
     response = client.get(f"{prefix}/.well-known/oauth-protected-resource/{path}")
     assert response.status_code == 200
     resource = response.json()
-    issuer_path = path if relay else "mcp"
+    issuer_path = server.server_name if relay else "mcp"
     assert resource["resource"] == f"http://testserver{prefix}/{path}"
     assert resource["authorization_servers"] == [f"http://testserver{prefix}/{issuer_path}"]
     authorization = client.get(f"{prefix}/.well-known/oauth-authorization-server/{issuer_path}")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Per-server OAuth metadata returns a mismatched issuer
- Prefixed legacy authorization discovery returns 404

How it solves it:

- Match each discovery path to its issuer
- Preserve aggregate and compatibility discovery behavior

## User Flow

Before: a client validating per-server authorization metadata rejects its issuer

1. Fetch `http://localhost:47078/.well-known/oauth-authorization-server/mcp/example`
2. Receive HTTP 200 with issuer `http://localhost:47078/example`
3. Validate against `http://localhost:47078/mcp/example` and receive `issuer property does not match the expected value`

After: the same discovery document passes strict issuer validation

1. Fetch `http://localhost:47078/.well-known/oauth-authorization-server/mcp/example`
2. Receive HTTP 200 with issuer `http://localhost:47078/mcp/example`
3. Validate against `http://localhost:47078/mcp/example` successfully and retain `/example/authorize`, `/example/token`, and `/example/register`

## Relevant issues

Related to #39665 and #40791. This addresses per-server issuer consistency independently of root authentication selection

## Linear ticket

Resolves LIT-7078

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The affected backend tests pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] Greptile confidence is at least 4/5

Local validation on `0690520080`: 484 affected discovery/BYOK tests passed. The new regression cases produce 13 failures and 11 passing compatibility/control cases against the merge base. Ruff lint/format, full test-tree lint, strict-rule, type-discipline, test-quality, and canonical basedpyright gates passed without budget changes

Local changed executable-line coverage is **2/2 (100%)**. The authorization metadata builder covers **6/6 branches**; both route handlers are fully covered and have no branches. These figures are separate from repository-wide coverage. Current-tip reviews are complete: Greptile **5/5**, Veria **success**, and Cursor Bugbot **no issues found**, all on `0690520080`. Review summaries, annotations, and inline threads have no unresolved actionable findings. The contributor confirmed the CLA is signed as `joshua-berri`; this PR exposes no separate CLA status. All 33 required CI checks passed. The [completed current-tip Codecov report](https://app.codecov.io/gh/BerriAI/litellm/commit/0690520080fde5f63878ac1b4f0e00cc19843f36) includes all 26 current-tip coverage flags: **2/2 changed lines covered (100%)**, with **80.67% repository-wide coverage**

A merge simulation with #40791 at `87e2e7afac` is clean. This patch preserves existing advertised relay identifiers, root discovery, and aggregate/BYOK behavior.

## Screenshots / Proof of Fix

Both images were built from the commits below with the repository Dockerfile and ran with isolated Docker Compose PostgreSQL on `localhost:47078`. The `example` server uses `auth_type: oauth2`, `oauth2_flow: authorization_code`, `per_server_oauth_discovery: true`, explicit GitHub OAuth URLs, and placeholder client credentials. Reading discovery does not need upstream login or an LLM call

[Validator, package integrity, screenshots, and raw results](https://github.com/BerriAI/litellm/tree/91b1989df04f21744807961a2d4d55252bf95a7f) use the unmodified `oauth4webapi@3.8.8` library against live HTTP responses. Copy its extracted package and `strict-discovery.mjs` into `/tmp` of the Compose gateway container. The script enables HTTP for localhost and maps transport port 47078 to the container's port 4000 while retaining the expected external issuer

### Before (e4706fa4090ba2f6d88532e63428ff32994a64df)

#### Per-server discovery

1. Run `curl -sS http://localhost:47078/.well-known/oauth-authorization-server/mcp/example`: HTTP 200, `issuer: http://localhost:47078/example`
2. Run `docker exec litellm-7078-repro-litellm-1 node /tmp/strict-discovery.mjs`: `/mcp/example` and `/example/mcp` both fail with `issuer property does not match the expected value`. The `/example`, `/mcp`, and root controls pass
3. Observe the browser response below

![Before: standard discovery returns the wrong issuer](https://raw.githubusercontent.com/BerriAI/litellm/91b1989df04f21744807961a2d4d55252bf95a7f/before-metadata.png)

#### Static deployment prefix

1. Set `SERVER_ROOT_PATH=/gateway` and `PROXY_BASE_URL=http://localhost:47078/gateway`, then recreate the gateway
2. Run `curl -i http://localhost:47078/.well-known/oauth-authorization-server/gateway/example/mcp`: HTTP 404
3. Run `docker exec -e REPRO_BASE_URL=http://localhost:47078/gateway litellm-7078-repro-litellm-1 node /tmp/strict-discovery.mjs`: standard discovery rejects the issuer; legacy discovery rejects the HTTP status. Compatibility and aggregate controls pass

#### Real public MCP tools

1. Configure `aws_knowledge_mcp` with URL `https://knowledge-mcp.global.api.aws`, HTTP transport, and `auth_type: none`
2. With a local gateway key, POST `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}` to `/mcp/aws_knowledge_mcp`: HTTP 200, five tools
3. POST `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"aws_knowledge_mcp-aws___list_regions","arguments":{}}}` to the same URL: HTTP 200, real AWS region data, `isError: false`

### After (0690520080fde5f63878ac1b4f0e00cc19843f36)

#### Per-server discovery

1. Run `curl -sS http://localhost:47078/.well-known/oauth-authorization-server/mcp/example`: HTTP 200, `issuer: http://localhost:47078/mcp/example`
2. Run `docker exec litellm-7078-repro-litellm-1 node /tmp/strict-discovery.mjs`: `/mcp/example` and `/example/mcp` both pass. The `/example`, `/mcp`, and root controls still pass
3. Observe the browser response below

![After: standard discovery returns the matching issuer](https://raw.githubusercontent.com/BerriAI/litellm/91b1989df04f21744807961a2d4d55252bf95a7f/after-metadata.png)

#### Static deployment prefix

1. Set `SERVER_ROOT_PATH=/gateway` and `PROXY_BASE_URL=http://localhost:47078/gateway`, then recreate the gateway
2. Run `curl -i http://localhost:47078/.well-known/oauth-authorization-server/gateway/example/mcp`: HTTP 200, `issuer: http://localhost:47078/gateway/example/mcp`
3. Run `docker exec -e REPRO_BASE_URL=http://localhost:47078/gateway litellm-7078-repro-litellm-1 node /tmp/strict-discovery.mjs`: all four prefixed discovery documents pass

#### Real public MCP tools

1. Configure `aws_knowledge_mcp` with URL `https://knowledge-mcp.global.api.aws`, HTTP transport, and `auth_type: none`
2. With a local gateway key, POST `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}` to `/mcp/aws_knowledge_mcp`: HTTP 200, five tools
3. POST `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"aws_knowledge_mcp-aws___list_regions","arguments":{}}}` to the same URL: HTTP 200, real AWS region data, `isError: false`

## Type

Bug Fix

## Caveats (if any)


## Final Attestation

- [x] Tests cover issuer paths, compatibility, and deployment prefixes
- [x] Required CI, coverage, contributor agreement, and current bot reviews verified
