### PR TITLE
docs(pr-template): note untested assumptions under Caveats

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -129,6 +129,23 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
      human reader
      Leave this section empty if there are none -->
 
+## Assumptions
+
+<!-- One bullet per claim this PR relies on that you did not actually test, each written as the claim
+     followed by what breaks if it turns out to be wrong. Write it for a reviewer who wants to attack
+     the weakest one, not to reassure them
+     Anything that narrows the scope of a bug belongs here unless you ran the test that proves it:
+     "only reproduces with X on", "no user-observable behavior difference", "this path is debug-only",
+     "no caller passes that shape". A claim you did verify is not an assumption; put the proof in
+     Screenshots / Proof of Fix instead
+     If the linked issue or ticket recorded something as untested or unverified, carry it into this
+     section or say here which run closed it out. Do not drop it silently
+     Example:
+     - The alert path is debug-only, so the growth cannot be hit at default log level. If a second
+       caller stringifies the same structure without a level gate, this ships the bug to every
+       deployment. Not tested: no run with the debug flag off
+     Write "None" if the change rests on nothing untested -->
+
 ## QA runbook
 
 <!-- Only needed when your PR edits tests/e2e; delete this section otherwise

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -129,7 +129,7 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
      human reader
      Leave this section empty if there are none -->
 
-## Assumptions
+## Assumptions Made
 
 <!-- One bullet per claim this PR relies on that you did not actually test, each written as the claim
      followed by what breaks if it turns out to be wrong. Write it for a reviewer who wants to attack

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -127,24 +127,9 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
      - Low: anything else worth noting: naming, cleanup, an edge case nobody hits
      Nest bullets as deep as helps: hierarchy beats one long line when it makes things clearer to a
      human reader
-     Leave this section empty if there are none
-
-     Also list, under an "### Assumptions Made" subheading, one bullet per claim this PR relies on
-     that you did not actually test, each written as the claim followed by what breaks if it turns
-     out to be wrong. Write it for a reviewer who wants to attack the weakest one, not to reassure
-     them. Anything that narrows the scope of a bug belongs here unless you ran the test that proves
-     it: "only reproduces with X on", "no user-observable behavior difference", "this path is
-     debug-only", "no caller passes that shape". A claim you did verify is not an assumption; put the
-     proof in Screenshots / Proof of Fix instead. If the linked issue or ticket recorded something as
-     untested or unverified, carry it into this subsection or say here which run closed it out. Do
-     not drop it silently
-     Example:
-     ### Assumptions Made
-     - The alert path is debug-only, so the growth cannot be hit at default log level. If a second
-       caller stringifies the same structure without a level gate, this ships the bug to every
-       deployment. Not tested: no run with the debug flag off
-     Include this subheading even when the rest of Caveats is empty; write "None" under it only if
-     the change rests on nothing untested -->
+     If you assumed something instead of testing it, e.g. "only reproduces with X on" or "no
+     user-observable behavior difference", list it here too with what breaks if it is wrong
+     Leave this section empty if there are none -->
 
 ## QA runbook
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,23 @@
      everyday engineering language, extremely parsable and readable at a glance. This goes double for
      the TLDR, User Flow, and Caveats sections -->
 
+## Assumptions Made
+
+<!-- One bullet per claim this PR relies on that you did not actually test, each written as the claim
+     followed by what breaks if it turns out to be wrong. Write it for a reviewer who wants to attack
+     the weakest one, not to reassure them
+     Anything that narrows the scope of a bug belongs here unless you ran the test that proves it:
+     "only reproduces with X on", "no user-observable behavior difference", "this path is debug-only",
+     "no caller passes that shape". A claim you did verify is not an assumption; put the proof in
+     Screenshots / Proof of Fix instead
+     If the linked issue or ticket recorded something as untested or unverified, carry it into this
+     section or say here which run closed it out. Do not drop it silently
+     Example:
+     - The alert path is debug-only, so the growth cannot be hit at default log level. If a second
+       caller stringifies the same structure without a level gate, this ships the bug to every
+       deployment. Not tested: no run with the debug flag off
+     Write "None" if the change rests on nothing untested -->
+
 ## TLDR
 
 <!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max -->
@@ -128,23 +145,6 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
      Nest bullets as deep as helps: hierarchy beats one long line when it makes things clearer to a
      human reader
      Leave this section empty if there are none -->
-
-## Assumptions Made
-
-<!-- One bullet per claim this PR relies on that you did not actually test, each written as the claim
-     followed by what breaks if it turns out to be wrong. Write it for a reviewer who wants to attack
-     the weakest one, not to reassure them
-     Anything that narrows the scope of a bug belongs here unless you ran the test that proves it:
-     "only reproduces with X on", "no user-observable behavior difference", "this path is debug-only",
-     "no caller passes that shape". A claim you did verify is not an assumption; put the proof in
-     Screenshots / Proof of Fix instead
-     If the linked issue or ticket recorded something as untested or unverified, carry it into this
-     section or say here which run closed it out. Do not drop it silently
-     Example:
-     - The alert path is debug-only, so the growth cannot be hit at default log level. If a second
-       caller stringifies the same structure without a level gate, this ships the bug to every
-       deployment. Not tested: no run with the debug flag off
-     Write "None" if the change rests on nothing untested -->
 
 ## QA runbook
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,23 +2,6 @@
      everyday engineering language, extremely parsable and readable at a glance. This goes double for
      the TLDR, User Flow, and Caveats sections -->
 
-## Assumptions Made
-
-<!-- One bullet per claim this PR relies on that you did not actually test, each written as the claim
-     followed by what breaks if it turns out to be wrong. Write it for a reviewer who wants to attack
-     the weakest one, not to reassure them
-     Anything that narrows the scope of a bug belongs here unless you ran the test that proves it:
-     "only reproduces with X on", "no user-observable behavior difference", "this path is debug-only",
-     "no caller passes that shape". A claim you did verify is not an assumption; put the proof in
-     Screenshots / Proof of Fix instead
-     If the linked issue or ticket recorded something as untested or unverified, carry it into this
-     section or say here which run closed it out. Do not drop it silently
-     Example:
-     - The alert path is debug-only, so the growth cannot be hit at default log level. If a second
-       caller stringifies the same structure without a level gate, this ships the bug to every
-       deployment. Not tested: no run with the debug flag off
-     Write "None" if the change rests on nothing untested -->
-
 ## TLDR
 
 <!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max -->
@@ -144,7 +127,24 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
      - Low: anything else worth noting: naming, cleanup, an edge case nobody hits
      Nest bullets as deep as helps: hierarchy beats one long line when it makes things clearer to a
      human reader
-     Leave this section empty if there are none -->
+     Leave this section empty if there are none
+
+     Also list, under an "### Assumptions Made" subheading, one bullet per claim this PR relies on
+     that you did not actually test, each written as the claim followed by what breaks if it turns
+     out to be wrong. Write it for a reviewer who wants to attack the weakest one, not to reassure
+     them. Anything that narrows the scope of a bug belongs here unless you ran the test that proves
+     it: "only reproduces with X on", "no user-observable behavior difference", "this path is
+     debug-only", "no caller passes that shape". A claim you did verify is not an assumption; put the
+     proof in Screenshots / Proof of Fix instead. If the linked issue or ticket recorded something as
+     untested or unverified, carry it into this subsection or say here which run closed it out. Do
+     not drop it silently
+     Example:
+     ### Assumptions Made
+     - The alert path is debug-only, so the growth cannot be hit at default log level. If a second
+       caller stringifies the same structure without a level gate, this ships the bug to every
+       deployment. Not tested: no run with the debug flag off
+     Include this subheading even when the rest of Caveats is empty; write "None" under it only if
+     the change rests on nothing untested -->
 
 ## QA runbook
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Untested scope claims disappear between a ticket and its fix
- Reviewers cannot see what the author did not check

How it solves it:

- Adds a line to the Caveats instructions covering untested assumptions
- Asks for each one plus its blast radius, listed as a caveat

## User Flow

Before: an author narrows a bug to one flag, and nothing in review surfaces that the narrowing was never tested

1. The ticket records "running without the debug flag was not tried" as unverified
2. The fix PR's description says the bug only happens with that flag on, stated as fact
3. A reviewer reads the PR, sees no place where untested claims go, and approves
4. The fix ships correct but framed as debug-only, so nobody backports it to the stable line
5. A deployment on default log level hits the same bug and goes down

After: the same narrowing has to be written down as a caveat, so a reviewer can challenge it

1. The ticket records the same hedge
2. The author lists it under Caveats: the bug is assumed debug-only, not tested with the flag off, and if wrong the growth reaches every deployment
3. The reviewer reads that bullet and asks for one run with the flag off, or accepts the risk knowingly
4. Either the claim is checked before merge, or the release notes describe the real blast radius

## Relevant issues

## Linear ticket

Resolves LIT-7612

## Pre-Submission checklist

- [ ] I have added meaningful tests (not applicable: this changes a markdown template with no code path to test)
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This changes a markdown template that GitHub renders into the PR description box, so the proof is the rendered template itself rather than a proxy call. This PR's own description does not show it: GitHub captures the template at the moment a PR is opened, and this one was opened from the branch that adds the section.

### Before (origin/litellm_internal_staging at 5fdc3260d1)

1. Open a new PR against `litellm_internal_staging` from any branch
2. The description box is prefilled with TLDR, User Flow, Relevant issues, Linear ticket, Pre-Submission checklist, Delays in PR merge, Screenshots / Proof of Fix, Type, Caveats, QA runbook, Final Attestation. There is no section for untested claims

### After (55c5babbc5)

1. Open a new PR whose base is this branch
2. The prefilled Caveats section's comment now tells the author to list any untested assumption there too, with what breaks if it is wrong, alongside the existing severity-tier guidance

## Type

📖 Documentation

## Caveats (if any)

### Low

- Nothing enforces the line; review has to ask for it
- Reviewers will actually notice an assumption sitting among unrelated caveats rather than skimming past it. Not tested: no reviewer has filled it out yet
- If authors read "Caveats (if any)" and skip the whole section when they think there are none, an untested assumption skips past too

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR (not applicable: no code changes, so no customer-facing regression surface)
