### PR TITLE
refactor(ui): separate general settings from router settings

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/general-settings/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/general-settings/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import GeneralSettings from "../router-settings/_components/general_settings";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function GeneralSettingsPage() {
+  const { accessToken, userRole, userId } = useAuthorized();
+  return <GeneralSettings section="general" userID={userId} userRole={userRole} accessToken={accessToken} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/legacyPageRoutes.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/legacyPageRoutes.ts
@@ -36,6 +36,7 @@ const LEGACY_PAGE_ROUTES: ReadonlyMap<string, string> = new Map(
     usage: "old-usage",
     "cost-optimization": "cost-optimization",
     agents: "agents",
+    "general-settings": "general-settings",
     "router-settings": "router-settings",
     users: "users",
     teams: "teams",

--- a/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.test.tsx
@@ -1,6 +1,6 @@
 import { renderWithProviders, screen, within } from "../../../../../tests/test-utils";
 import userEvent from "@testing-library/user-event";
-import { vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import GeneralSettings from "./general_settings";
 import { deleteConfigFieldSetting, getGeneralSettingsCall, updateConfigFieldSetting } from "@/components/networking";
 
@@ -64,18 +64,17 @@ const settingsRow = async (fieldName: string) => {
 
 const numericValueIn = (row: HTMLElement) => Number((within(row).getByRole("spinbutton") as HTMLInputElement).value);
 
-describe("GeneralSettings General tab", () => {
+describe("GeneralSettings page", () => {
   beforeEach(() => {
     vi.mocked(getGeneralSettingsCall).mockResolvedValue([...SETTINGS_FIXTURE.map((s) => ({ ...s }))]);
     vi.mocked(updateConfigFieldSetting).mockClear();
     vi.mocked(deleteConfigFieldSetting).mockClear();
   });
 
-  it("updates max_ui_session_budget with its own value, not the value at its filtered index", async () => {
+  it("should update max_ui_session_budget with its own value, not the value at its filtered index", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<GeneralSettings accessToken="token" userRole="Admin" userID="user" />);
+    renderWithProviders(<GeneralSettings section="general" accessToken="token" userRole="Admin" userID="user" />);
 
-    await user.click(screen.getByText("General"));
     const row = await settingsRow("max_ui_session_budget");
 
     await user.click(within(row).getByRole("button", { name: /update/i }));
@@ -83,11 +82,10 @@ describe("GeneralSettings General tab", () => {
     expect(updateConfigFieldSetting).toHaveBeenCalledWith("token", "max_ui_session_budget", 7.5);
   });
 
-  it("reset shows the field's default value instead of an empty input", async () => {
+  it("should show the field's default value after reset", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<GeneralSettings accessToken="token" userRole="Admin" userID="user" />);
+    renderWithProviders(<GeneralSettings section="general" accessToken="token" userRole="Admin" userID="user" />);
 
-    await user.click(screen.getByText("General"));
     const row = await settingsRow("max_ui_session_budget");
     expect(numericValueIn(row)).toBe(7.5);
 
@@ -101,18 +99,35 @@ describe("GeneralSettings General tab", () => {
   });
 });
 
-// The five tabs here are proxy-wide settings. Auto-routers moved to Models + Endpoints.
-describe("GeneralSettings tabs", () => {
+describe("GeneralSettings navigation", () => {
   beforeEach(() => {
-    vi.mocked(getGeneralSettingsCall).mockResolvedValue([]);
+    vi.mocked(getGeneralSettingsCall).mockResolvedValue(SETTINGS_FIXTURE);
   });
 
-  it("renders the proxy-wide tabs and no auto-router tab", async () => {
-    renderWithProviders(<GeneralSettings accessToken="token" userRole="proxy_admin" userID="u" />);
+  it("should show the existing General fields without the router tabs or prompt caching controls", async () => {
+    renderWithProviders(<GeneralSettings section="general" accessToken="token" userRole="proxy_admin" userID="u" />);
 
-    for (const name of ["Loadbalancing", "Routing Groups", "Fallbacks", "Prompt Caching", "General"]) {
-      expect(await screen.findByRole("tab", { name })).toBeInTheDocument();
-    }
-    expect(screen.queryByRole("tab", { name: /auto.?router/i })).not.toBeInTheDocument();
+    await screen.findByRole("row", { name: /max_ui_session_budget/ });
+
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+    expect(screen.getAllByRole("spinbutton")).toHaveLength(2);
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
+
+  it("should keep the four router tabs with Prompt Caching and exclude the General table", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<GeneralSettings section="router" accessToken="token" userRole="proxy_admin" userID="u" />);
+
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "Loadbalancing",
+      "Routing Groups",
+      "Fallbacks",
+      "Prompt Caching",
+    ]);
+    await user.click(screen.getByRole("tab", { name: "Prompt Caching" }));
+
+    expect(await screen.findByText("Automatic Anthropic prompt caching")).toBeInTheDocument();
+    expect(screen.queryByRole("row", { name: /max_ui_session_budget/, hidden: true })).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
@@ -20,6 +20,7 @@ const ENABLE_ANTHROPIC_PROMPT_CACHING = "enable_anthropic_prompt_caching";
 const ANTHROPIC_PROMPT_CACHING_TTL = "anthropic_prompt_caching_ttl";
 
 interface GeneralSettingsPageProps {
+  section: "general" | "router";
   accessToken: string | null;
   userRole: string | null;
   userID: string | null;
@@ -183,7 +184,7 @@ export const PromptCachingPanel: React.FC<{
   );
 };
 
-const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, userRole, userID }) => {
+const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, userRole, userID, section }) => {
   const [generalSettings, setGeneralSettings] = useState<generalSettingsItem[]>([]);
 
   useEffect(() => {
@@ -251,6 +252,69 @@ const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, user
     return null;
   }
 
+  if (section === "general") {
+    return (
+      <div className="w-full px-8 py-6">
+        <Card>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Setting</TableHead>
+                  <TableHead>Value</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Action</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {generalSettings
+                  .filter((value) => value.field_type !== "TypedDictionary" && value.field_tab !== PROMPT_CACHING_TAB)
+                  .map((value, index) => (
+                    <TableRow key={index}>
+                      <TableCell className="whitespace-normal">
+                        <p className="break-words">{value.field_name}</p>
+                        <p
+                          style={{
+                            fontSize: "0.65rem",
+                            color: "#808080",
+                            fontStyle: "italic",
+                          }}
+                          className="mt-1 break-words"
+                        >
+                          {value.field_description}
+                        </p>
+                      </TableCell>
+                      <TableCell>
+                        <SettingValueEditor setting={value} onChange={handleInputChange} />
+                      </TableCell>
+                      <TableCell>
+                        {value.stored_in_db == true ? (
+                          <StatusBadge tone="success" label="In DB" />
+                        ) : value.stored_in_db == false ? (
+                          <StatusBadge tone="neutral" label="In Config" />
+                        ) : (
+                          <StatusBadge tone="neutral" label="Not Set" />
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Button onClick={() => handleUpdateField(value.field_name)}>Update</Button>
+                        <span
+                          onClick={() => handleResetField(value.field_name)}
+                          className="inline-flex shrink-0 cursor-pointer items-center justify-center px-1.5 py-1.5 text-destructive"
+                        >
+                          <Trash2 className="h-5 w-5 shrink-0" />
+                        </span>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   return (
     <div className="w-full">
       <Tabs defaultValue="loadbalancing" className="h-[75vh] w-full">
@@ -259,7 +323,6 @@ const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, user
           <TabsTrigger value="routing-groups">Routing Groups</TabsTrigger>
           <TabsTrigger value="fallbacks">Fallbacks</TabsTrigger>
           <TabsTrigger value="prompt-caching">Prompt Caching</TabsTrigger>
-          <TabsTrigger value="general">General</TabsTrigger>
         </TabsList>
         <TabsContent value="loadbalancing" className="px-8 py-6" keepMounted>
           <RouterSettings accessToken={accessToken} userRole={userRole} userID={userID} />
@@ -272,64 +335,6 @@ const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, user
         </TabsContent>
         <TabsContent value="prompt-caching" className="px-8 py-6" keepMounted>
           <PromptCachingPanel accessToken={accessToken} settings={generalSettings} onChange={handleInputChange} />
-        </TabsContent>
-        <TabsContent value="general" className="px-8 py-6" keepMounted>
-          <Card>
-            <CardContent>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Setting</TableHead>
-                    <TableHead>Value</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Action</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {generalSettings
-                    .filter((value) => value.field_type !== "TypedDictionary" && value.field_tab !== PROMPT_CACHING_TAB)
-                    .map((value, index) => (
-                      <TableRow key={index}>
-                        <TableCell className="whitespace-normal">
-                          <p className="break-words">{value.field_name}</p>
-                          <p
-                            style={{
-                              fontSize: "0.65rem",
-                              color: "#808080",
-                              fontStyle: "italic",
-                            }}
-                            className="mt-1 break-words"
-                          >
-                            {value.field_description}
-                          </p>
-                        </TableCell>
-                        <TableCell>
-                          <SettingValueEditor setting={value} onChange={handleInputChange} />
-                        </TableCell>
-                        <TableCell>
-                          {value.stored_in_db == true ? (
-                            <StatusBadge tone="success" label="In DB" />
-                          ) : value.stored_in_db == false ? (
-                            <StatusBadge tone="neutral" label="In Config" />
-                          ) : (
-                            <StatusBadge tone="neutral" label="Not Set" />
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          <Button onClick={() => handleUpdateField(value.field_name)}>Update</Button>
-                          <span
-                            onClick={() => handleResetField(value.field_name)}
-                            className="inline-flex shrink-0 cursor-pointer items-center justify-center px-1.5 py-1.5 text-destructive"
-                          >
-                            <Trash2 className="h-5 w-5 shrink-0" />
-                          </span>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
         </TabsContent>
       </Tabs>
     </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/router-settings/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/router-settings/page.tsx
@@ -5,5 +5,5 @@ import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 export default function RouterSettingsPage() {
   const { accessToken, userRole, userId } = useAuthorized();
-  return <GeneralSettings userID={userId} userRole={userRole} accessToken={accessToken} />;
+  return <GeneralSettings section="router" userID={userId} userRole={userRole} accessToken={accessToken} />;
 }

--- a/ui/litellm-dashboard/src/components/leftnav.test.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.test.tsx
@@ -239,6 +239,28 @@ describe("Sidebar (leftnav)", () => {
     expect(placementsOf("router-settings")).toEqual(["SETTINGS > settings"]);
   });
 
+  it.each([
+    ["admin", false],
+    ["admin", true],
+    ["internal", false],
+  ])(
+    "should expose General Settings alongside Router Settings only to admins (role=%s, viewOnly=%s)",
+    (role, viewOnly) => {
+      mockUseAuthorized.mockReturnValue({ ...mockUseAuthorized(), userRole: role, isViewOnly: viewOnly });
+      navState.pathname = "/ui/general-settings";
+      renderWithProviders(<Sidebar {...defaultProps} />);
+
+      if (role === "admin") {
+        expect(screen.getByRole("link", { name: "General Settings" })).toHaveAttribute("href", "/ui/general-settings");
+        expect(screen.getByRole("link", { name: "Router Settings" })).toHaveAttribute("href", "/ui/router-settings");
+      } else {
+        expect(screen.queryByRole("link", { name: "General Settings" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: "Router Settings" })).not.toBeInTheDocument();
+      }
+      expect(placementsOf("general-settings")).toEqual(["SETTINGS > settings"]);
+    },
+  );
+
   it("has no duplicate keys among all menu items and their children", () => {
     // React keys must be unique across the whole nav config, otherwise the
     // active-item highlight and group expansion collide.
@@ -612,6 +634,10 @@ describe("getBreadcrumb", () => {
 
   it("resolves a nested child route to its parent section", () => {
     expect(getBreadcrumb("/ui/search-tools/")).toEqual({ section: "AI Gateway", title: "Search Tools" });
+  });
+
+  it("should resolve General Settings under the Settings section", () => {
+    expect(getBreadcrumb("/ui/general-settings/")).toEqual({ section: "Settings", title: "General Settings" });
   });
 
   it("resolves router-settings under the Settings section", () => {

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -328,6 +328,13 @@ const menuGroups: MenuGroup[] = [
         roles: all_admin_roles,
         children: [
           {
+            key: "general-settings",
+            page: "general-settings",
+            label: "General Settings",
+            icon: <SettingsIcon {...ICON} />,
+            roles: all_admin_roles,
+          },
+          {
             key: "router-settings",
             page: "router-settings",
             label: "Router Settings",

--- a/ui/litellm-dashboard/src/components/page_metadata.ts
+++ b/ui/litellm-dashboard/src/components/page_metadata.ts
@@ -39,6 +39,7 @@ export const pageDescriptions: Record<string, string> = {
   prompts: "Manage and version prompt templates",
   skills: "Browse and manage Claude Code skills",
   usage: "View legacy usage dashboard",
+  "general-settings": "Configure general proxy settings",
   "router-settings": "Configure routing and load balancing settings",
   "logging-and-alerts": "Set up logging and alert configurations",
   "admin-panel": "Access admin panel and settings",


### PR DESCRIPTION
## TLDR

Problem this solves:

- General proxy settings are nested under Router Settings

How it solves it:

- Move the existing table to Settings > General Settings
- Reuse all existing fields, controls, filters, and save/reset behavior
- Keep the four remaining Router Settings tabs

## User Flow

Before: admins must open Router Settings to find general settings

1. Open Settings in the admin dashboard sidebar
2. Open http://localhost:59691/router-settings/ and select General
3. Edit the existing general settings table

After: admins can reach general settings directly from Settings

1. Open Settings in the admin dashboard sidebar
2. Open General Settings at http://localhost:59691/general-settings/
3. Edit the same general settings table

## Linear ticket

Resolves LIT-5882

## Pre-Submission checklist

- [x] Added focused navigation and settings separation tests
- [x] 67 tests across six relevant files passed locally
- [x] `make check` passed, including dashboard formatting, lint, and budgets
- [ ] All required CI/CD checks passed
- [x] Scope is limited to relocating existing UI
- [ ] Greptile has posted 5/5 for the current head

## Screenshots / Proof of Fix

Verified in a live local dashboard connected to an isolated proxy and PostgreSQL database, without network mocks

Screenshots were captured locally; attachment upload is pending because the available GitHub browser session is signed out

### Before (b27d2cce77)

1. Open http://localhost:59691/router-settings/ and select General
2. Observe the existing table under Router Settings: 32 rows, 23 editors
3. Observe that Settings has no separate General Settings entry

### After (e9a20fbf1c)

1. Open http://localhost:59691/router-settings/: Loadbalancing, Routing Groups, Fallbacks, and Prompt Caching remain
2. Open Settings > General Settings at http://localhost:59691/general-settings/
3. Observe the same 32 fields in the same order with the same 23 editor types; the before/after DOM inventories match exactly
4. Save `max_ui_session_budget` as `7.5`, reload, and observe `7.5` with In DB status; reset and reload, and observe the original `1` with Not Set status

## Type

Refactoring

## Caveats

### Medium

- Existing fields without editors remain without editors
- Backend persistence and runtime application are outside this UI move
- Full `tsc --noEmit` fails in unmodified dashboard files

### Low

- Screenshot attachment upload is pending

## Final Attestation

- [ ] All required CI and current-head review gates are complete
