### PR TITLE
fix(proxy): gate the webhook test alert on proxy admins

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -437,6 +437,11 @@ async def health_services_endpoint(
             }
             return pointfive_health
         if service == "webhook":
+            if not _is_proxy_admin(user_api_key_dict):
+                webhook_non_admin_detail: Final[_ServiceTestErrorDetail] = {
+                    "error": "Only proxy admins can trigger the webhook test alert."
+                }
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=webhook_non_admin_detail)
             user_info: Final = CallInfo(
                 token=user_api_key_dict.token or "",
                 spend=1,

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1191,6 +1191,61 @@ async def test_health_services_endpoint_newrelic_allows_proxy_admin(admin_role):
         mock_instance.async_health_check.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "role",
+    [
+        None,
+        LitellmUserRoles.INTERNAL_USER,
+        LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
+        LitellmUserRoles.TEAM,
+        LitellmUserRoles.CUSTOMER,
+    ],
+)
+async def test_health_services_endpoint_webhook_blocks_non_admin(role):
+    """
+    /health/services?service=webhook fires a real budget_crossed alert for the
+    caller's user_id and writes the same dedup cache entry the auth-time user
+    budget alert uses, so a non-admin could suppress their own real alert for
+    the cache TTL. Only proxy admins may trigger it.
+    """
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.budget_alerts = AsyncMock()
+    user_api_key_dict = UserAPIKeyAuth(token="non-admin-token", user_id="non-admin-user", user_role=role)
+
+    with patch(  # test-quality-ok: endpoint reads proxy_server module globals, same pattern as sibling tests
+        "litellm.proxy.proxy_server.proxy_logging_obj",
+        mock_proxy_logging,
+    ):
+        with pytest.raises(ProxyException) as exc_info:
+            await health_services_endpoint(user_api_key_dict=user_api_key_dict, service="webhook")
+
+    assert str(exc_info.value.code) == "403"
+    mock_proxy_logging.budget_alerts.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "admin_role",
+    [LitellmUserRoles.PROXY_ADMIN, LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY],
+)
+async def test_health_services_endpoint_webhook_allows_proxy_admin(admin_role):
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.budget_alerts = AsyncMock()
+    user_api_key_dict = UserAPIKeyAuth(token="admin-token", user_id="admin-user", user_role=admin_role)
+
+    with patch(  # test-quality-ok: endpoint reads proxy_server module globals, same pattern as sibling tests
+        "litellm.proxy.proxy_server.proxy_logging_obj",
+        mock_proxy_logging,
+    ):
+        await health_services_endpoint(user_api_key_dict=user_api_key_dict, service="webhook")
+
+    mock_proxy_logging.budget_alerts.assert_awaited_once()
+    sent = mock_proxy_logging.budget_alerts.await_args.kwargs
+    assert sent["type"] == "user_budget"
+    assert sent["user_info"].user_id == "admin-user"
+
+
 @pytest.fixture(scope="function")
 def proxy_client(monkeypatch):
     """


### PR DESCRIPTION
## TLDR

Problem this solves:

- Any authenticated key could fire the webhook test alert
- That test alert poisons the caller's own budget-alert dedup entry
- A user could silence their real budget alert for the cache TTL

How it solves it:

- `/health/services?service=webhook` now returns 403 for non-admins
- Matches the existing New Relic and PointFive admin gates

## User Flow

Before: an internal user can fire the webhook test alert against their own user id, and once #40396 lands that suppresses the real alert operators rely on

1. A proxy admin configures `alerting: ["webhook"]` and creates an internal user with a $100 budget through POST http://localhost:4000/user/new with `auto_create_key: true`
2. That user sends GET http://localhost:4000/health/services?service=webhook with their personal key
3. The request returns HTTP 200 and the operator's webhook receives a `budget_crossed` event carrying that user's `user_id` with `spend: 1.0` and `max_budget: 0.0`
4. When that user later really crosses $100, the proxy still blocks them with HTTP 429, but the `budget_crossed` webhook for that user is skipped for the rest of the dedup window because the test event already claimed it
5. Another user can do the same for their own id, so every internal user can mute their own budget alert

After: only proxy admins can fire the webhook test alert, so a user cannot pre-claim their own dedup entry

1. A proxy admin configures `alerting: ["webhook"]` and creates an internal user with a $100 budget through POST http://localhost:4000/user/new with `auto_create_key: true`
2. That user sends GET http://localhost:4000/health/services?service=webhook with their personal key
3. The request returns HTTP 403 with `Only proxy admins can trigger the webhook test alert.` and the operator's webhook receives nothing
4. The proxy admin sends the same GET with the master key, gets HTTP 200, and the webhook receives the test `budget_crossed` event as before
5. Another user cannot fire the test alert for their own id either, so their real `budget_crossed` webhook is delivered when they cross their limit

## Relevant issues

Follow-up to #40396, which adds the auth-time internal user budget alert that shares the dedup cache entry this test alert writes

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs used the same local PostgreSQL database, the same config, and a local webhook receiver on 127.0.0.1:4761 that appends every POST body to `alerts.jsonl`. `WEBHOOK_URL=http://127.0.0.1:4761/` was set in the proxy's environment

```yaml
model_list:
  - model_name: claude-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

general_settings:
  master_key: sk-1234
  database_url: os.environ/DATABASE_URL
  alerting: ["webhook"]
  alert_types: ["budget_alerts"]
```

Shared setup for each run:

```bash
USER_KEY="$(curl -fsS -X POST http://127.0.0.1:$PORT/user/new \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d "{\"user_id\":\"$USER_ID\",\"user_role\":\"internal_user\",\"max_budget\":100.0,\"models\":[\"claude-haiku-4-5\"],\"auto_create_key\":true}" \
  | jq -er '.key')"
```

### Before (b27d2cce77)

#### internal user calls the webhook test

1. Ran:

   ```bash
   curl -sS -w 'HTTP %{http_code}\n' "http://127.0.0.1:4762/health/services?service=webhook" -H "Authorization: Bearer $USER_KEY"
   jq -c 'select(.user_id == "webhook-gate-before-1789174975")' alerts.jsonl
   ```

2. Observed output:

   ```text
   null
   HTTP 200
   {"event":"budget_crossed","event_group":"key","user_id":"webhook-gate-before-1789174975","spend":1.0,"max_budget":0.0}
   ```

#### proxy admin calls the webhook test

1. Ran:

   ```bash
   curl -sS -w 'HTTP %{http_code}\n' "http://127.0.0.1:4762/health/services?service=webhook" -H 'Authorization: Bearer sk-1234'
   jq -c '.' alerts.jsonl
   ```

2. Observed output:

   ```text
   null
   HTTP 200
   {"event":"budget_crossed","event_group":"key","user_id":"default_user_id","spend":1.0,"max_budget":0.0}
   ```

### After (0c9fda8c1e)

#### internal user calls the webhook test

1. Ran:

   ```bash
   curl -sS -w 'HTTP %{http_code}\n' "http://127.0.0.1:4763/health/services?service=webhook" -H "Authorization: Bearer $USER_KEY"
   jq -c 'select(.user_id == "webhook-gate-after-1789175010")' alerts.jsonl
   ```

2. Observed output:

   ```text
   {"error":{"message":"{'error': 'Only proxy admins can trigger the webhook test alert.'}","type":"auth_error","param":"None","code":"403"}}
   HTTP 403
   ```

   `alerts.jsonl` stayed empty for this user

#### proxy admin calls the webhook test

1. Ran:

   ```bash
   curl -sS -w 'HTTP %{http_code}\n' "http://127.0.0.1:4763/health/services?service=webhook" -H 'Authorization: Bearer sk-1234'
   jq -c '.' alerts.jsonl
   ```

2. Observed output:

   ```text
   null
   HTTP 200
   {"event":"budget_crossed","event_group":"key","user_id":"default_user_id","spend":1.0,"max_budget":0.0}
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The endpoint docstring already said admin-only, so this is the code catching up to the contract
- Non-admin callers now get 403 instead of 200 on this one service value
- The Admin UI only fires this test from the Alerting settings page, which admins already own
- The other alert-firing services (`slack`, `slack_budget_alerts`, `email`) are still open to any key; they do not touch the per-user dedup entry so they are out of scope here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
