### PR TITLE
fix(s3): bound object key filenames

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -49,6 +49,8 @@ DEFAULT_S3_FLUSH_INTERVAL_SECONDS: Final = int(os.getenv("DEFAULT_S3_FLUSH_INTER
 DEFAULT_S3_BATCH_SIZE: Final = int(os.getenv("DEFAULT_S3_BATCH_SIZE", 512))
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
 MAX_S3_OBJECT_KEY_BYTES: Final = 1024
+# Filesystem-backed S3-compatible stores commonly limit object filenames to 255 bytes
+MAX_S3_OBJECT_KEY_FILENAME_BYTES: Final = 255
 S3_BOUNDED_OBJECT_KEY_HEAD_BYTES: Final = 64
 S3_PREFIX_DIGEST_CHARS: Final = 16
 # s3 allows 2048 bytes of combined metadata headers, which Content-Disposition counts against

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -49,7 +49,6 @@ DEFAULT_S3_FLUSH_INTERVAL_SECONDS: Final = int(os.getenv("DEFAULT_S3_FLUSH_INTER
 DEFAULT_S3_BATCH_SIZE: Final = int(os.getenv("DEFAULT_S3_BATCH_SIZE", 512))
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
 MAX_S3_OBJECT_KEY_BYTES: Final = 1024
-# Filesystem-backed S3-compatible stores commonly limit object filenames to 255 bytes
 MAX_S3_OBJECT_KEY_FILENAME_BYTES: Final = 255
 S3_BOUNDED_OBJECT_KEY_HEAD_BYTES: Final = 64
 S3_PREFIX_DIGEST_CHARS: Final = 16

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -10,6 +10,7 @@ from litellm._logging import print_verbose, verbose_logger
 from litellm.constants import (
     MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES,
     MAX_S3_OBJECT_KEY_BYTES,
+    MAX_S3_OBJECT_KEY_FILENAME_BYTES,
     S3_BOUNDED_OBJECT_KEY_HEAD_BYTES,
     S3_PREFIX_DIGEST_CHARS,
 )
@@ -253,21 +254,28 @@ def get_s3_object_key(
     sanitized_s3_file_name: Final = s3_file_name.replace("/", "_")
     configured_prefix: Final = (s3_path.rstrip("/") + "/" if s3_path else "") + prefix
     date_segment: Final = start_time.strftime("%Y-%m-%d") + "/"
+    extension: Final = ".json"
+    file_name_budget: Final = MAX_S3_OBJECT_KEY_FILENAME_BYTES - len(extension.encode("utf-8"))
     # we need the s3 key to include the time, so we log cache hits too
-    s3_object_key: Final = configured_prefix + date_segment + sanitized_s3_file_name + ".json"
-    if len(s3_object_key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES:
+    s3_object_key: Final = configured_prefix + date_segment + sanitized_s3_file_name + extension
+    if (
+        len(s3_object_key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES
+        and len(sanitized_s3_file_name.encode("utf-8")) <= file_name_budget
+    ):
         return s3_object_key
 
     # shorten the response id first and only trim the configured prefix if that is what does not
     # fit, so prefix scoped IAM policies and lifecycle rules keep matching
-    budget: Final = MAX_S3_OBJECT_KEY_BYTES - len(date_segment.encode("utf-8")) - len(b".json")
+    budget: Final = MAX_S3_OBJECT_KEY_BYTES - len(date_segment.encode("utf-8")) - len(extension.encode("utf-8"))
     prefix_bytes: Final = len(configured_prefix.encode("utf-8"))
     if prefix_bytes + S3_MIN_BOUNDED_FILE_NAME_BYTES <= budget:
-        bounded_file_name: Final = _bounded_s3_file_name(s3_file_name, sanitized_s3_file_name, budget - prefix_bytes)
-        return configured_prefix + date_segment + bounded_file_name + ".json"
+        bounded_file_name: Final = _bounded_s3_file_name(
+            s3_file_name, sanitized_s3_file_name, min(file_name_budget, budget - prefix_bytes)
+        )
+        return configured_prefix + date_segment + bounded_file_name + extension
 
     shortest_file_name: Final = _bounded_s3_file_name(
         s3_file_name, sanitized_s3_file_name, S3_MIN_BOUNDED_FILE_NAME_BYTES
     )
     bounded_prefix: Final = _bounded_s3_prefix(configured_prefix, budget - len(shortest_file_name.encode("utf-8")))
-    return bounded_prefix + date_segment + shortest_file_name + ".json"
+    return bounded_prefix + date_segment + shortest_file_name + extension

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1311,25 +1311,76 @@ def test_create_s3_batch_logging_element_flat_key_for_arn_response_id():
 
 
 # --------------------------------------------------------------
-# object keys bounded to S3's 1024 UTF-8 byte limit
+# object keys bounded to S3 and filesystem-compatible limits
 # --------------------------------------------------------------
 def _oversized_response_id() -> str:
     return "resp_" + "A" * 1100
 
 
-def test_s3_object_key_at_the_byte_limit_is_left_alone():
-    """A key that still fits is left byte-identical."""
-    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+def test_s3_object_key_at_the_segment_byte_limit_is_left_alone():
+    """A final key segment that still fits is left byte-identical."""
     from litellm.integrations.s3 import get_s3_object_key
 
     start_time = datetime(2026, 8, 24, 6, 18, 41, 948021)
-    fixed_len = len("input/2026-08-24/.json")
-    file_name = "x" * (MAX_S3_OBJECT_KEY_BYTES - fixed_len)
+    file_name = "x" * 250
 
     key = get_s3_object_key(s3_path="input", prefix="", start_time=start_time, s3_file_name=file_name)
 
     assert key == f"input/2026-08-24/{file_name}.json"
-    assert len(key.encode("utf-8")) == MAX_S3_OBJECT_KEY_BYTES
+    assert len(key.rsplit("/", 1)[1].encode("utf-8")) == 255
+
+
+def test_s3_object_key_just_over_the_file_name_limit_is_bounded():
+    """A 256-byte final key segment is shortened below the local filesystem limit."""
+    from litellm.integrations.s3 import get_s3_object_key
+
+    key = get_s3_object_key(
+        s3_path="input",
+        prefix="",
+        start_time=datetime(2026, 8, 24, 6, 18, 41, 948021),
+        s3_file_name="x" * 251,
+    )
+
+    assert len(key.rsplit("/", 1)[1].encode("utf-8")) <= 255
+
+
+def test_s3_object_key_bounds_the_file_segment_when_the_full_key_fits():
+    """A locally stored object name is bounded even when its full S3 key is below 1024 bytes."""
+    import hashlib
+
+    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+    from litellm.integrations.s3 import get_s3_object_key
+
+    file_name = "time-01-14-19-015434_resp_" + "A" * 300
+
+    key = get_s3_object_key(
+        s3_path="requests",
+        prefix="",
+        start_time=datetime(2026, 9, 12, 1, 14, 19, 15434),
+        s3_file_name=file_name,
+    )
+
+    file_segment = key.rsplit("/", 1)[1]
+    assert len(key.encode("utf-8")) < MAX_S3_OBJECT_KEY_BYTES
+    assert len(file_segment.encode("utf-8")) <= 255
+    assert file_segment.startswith("time-01-14-19-015434_resp_")
+    assert file_segment.endswith(f"_{hashlib.sha256(file_name.encode('utf-8')).hexdigest()}.json")
+
+
+def test_s3_object_key_file_segment_limit_counts_utf8_bytes():
+    """The final key segment is bounded by encoded bytes without splitting a character."""
+    from litellm.integrations.s3 import get_s3_object_key
+
+    key = get_s3_object_key(
+        s3_path="requests",
+        prefix="",
+        start_time=datetime(2026, 9, 12, 1, 14, 19, 15434),
+        s3_file_name="time-01-14-19-015434_resp_" + "日" * 100,
+    )
+
+    file_segment = key.rsplit("/", 1)[1]
+    assert len(file_segment.encode("utf-8")) <= 255
+    assert "\ufffd" not in file_segment
 
 
 def test_s3_object_key_is_bounded_for_oversized_response_id():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Filesystem-backed S3 stores reject filenames over 255 bytes
- Valid AWS S3 keys can still fail on MinIO or RustFS
- Long keys are difficult to download onto local filesystems

How it solves it:

- Limits the final object-key filename to 255 UTF-8 bytes
- Reuses the existing readable-prefix plus SHA-256 strategy
- Keeps short object keys unchanged

## Background

Commit [`cdb1245e7419fa8b0294da3946cbad68b3d567d5`](https://github.com/BerriAI/litellm/commit/cdb1245e7419fa8b0294da3946cbad68b3d567d5), merged through [#39164](https://github.com/BerriAI/litellm/pull/39164), added shared handling for S3's 1024-byte object-key limit and the Content-Disposition metadata limit

That change correctly handles AWS S3 limits, but filesystem-backed S3-compatible implementations have another constraint: the final filename commonly cannot exceed 255 bytes

For example, this object key is only 395 bytes in total, so it is valid under the S3 object-key limit:

```text
requests/2026-09-12/time-01-14-19-015434_resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDpOb25lO3Jlc3BvbnNlX2lkOnJlc3BfMmM3NzViZDI5QzFLSldyM1ZjQUhDdmxJaW9TNHNtREhia0t3cm5MZHFHR1BGZEJEbm9rZ19HbHdoOEpvRFFIV3lHM2RvTFJ6azhRd1lub2FHRk1QUjNxRW4wX1hkYmM1MURSWmVRQ1hPLTNaa3pJbktocHlqV0JlNVFJejZEbkRCMjBrNmwwUXhZSUpOYm1SNEtaTHJtS0drTnRNNktxVWotWnJCckZlajBINEw0RWJQNHZhVGl2SElEZw%3D%3D.json
```

Its final filename is 375 bytes, which exceeds the common 255-byte filesystem limit. Uploading it through `s3_v2` to a locally deployed MinIO or RustFS instance can therefore fail with an HTTP 400 or 500 response

This problem was originally reported in [#24628](https://github.com/BerriAI/litellm/issues/24628). Four related attempts, [#24637](https://github.com/BerriAI/litellm/pull/24637), [#24642](https://github.com/BerriAI/litellm/pull/24642), [#24671](https://github.com/BerriAI/litellm/pull/24671), and [#24672](https://github.com/BerriAI/litellm/pull/24672), were closed without merging, and the issue was eventually closed as stale

Now is a good time to address it because #39164 already introduced the shared object-key bounding behavior. This PR is a small extension of that accepted design rather than a separate truncation mechanism

It adds a second invariant to the existing key builder:

- The complete object key remains within S3's 1024-byte limit
- The final filename remains within 255 UTF-8 bytes
- Ordinary filenames remain unchanged
- Oversized filenames retain a readable prefix and SHA-256 digest
- The complete response ID remains available inside the JSON payload

Besides improving `s3_v2` compatibility with locally deployed MinIO and RustFS instances, the shorter filenames also make exported S3 logs easier to download and analyze on local filesystems without `filename too long` errors

## User Flow

Before: a proxy admin using a filesystem-backed S3-compatible store loses logs whose response IDs produce oversized filenames

1. The admin configures LiteLLM S3 logging with a local MinIO or RustFS endpoint
2. A client sends `POST https://<litellm-domain>/v1/responses` and receives a long response ID
3. LiteLLM attempts to upload a key whose final filename exceeds 255 bytes
4. The S3-compatible store returns HTTP 400 or 500 and the log is not uploaded
5. Exporting a similarly named object to a local filesystem can also fail with `filename too long`

After: the same request is stored with a portable filename while preserving its full response ID

1. The admin configures LiteLLM S3 logging with the same local MinIO or RustFS endpoint
2. A client sends `POST https://<litellm-domain>/v1/responses` and receives the same long response ID
3. LiteLLM shortens the final filename to a readable prefix plus SHA-256 digest
4. The S3-compatible store accepts the filename because it is at most 255 UTF-8 bytes
5. The object can be downloaded to a local filesystem, and its JSON payload still contains the full response ID

## Relevant issues

Addresses [#24628](https://github.com/BerriAI/litellm/issues/24628)

Builds on [#39164](https://github.com/BerriAI/litellm/pull/39164) and commit [`cdb1245e7419fa8b0294da3946cbad68b3d567d5`](https://github.com/BerriAI/litellm/commit/cdb1245e7419fa8b0294da3946cbad68b3d567d5)

Previous unmerged attempts:

- [#24637](https://github.com/BerriAI/litellm/pull/24637)
- [#24642](https://github.com/BerriAI/litellm/pull/24642)
- [#24671](https://github.com/BerriAI/litellm/pull/24671)
- [#24672](https://github.com/BerriAI/litellm/pull/24672)

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] The complete affected test files pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] My PR has received a Greptile Confidence Score of at least 4/5

## Type

Bug Fix

## Caveats

### Low

- Live MinIO and RustFS verification is pending CI or maintainer testing

## Final Attestation

- [x] The tests cover the 255-byte boundary and reported failure mode

CC: @mateo-berri @yucheng-berri 