### PR TITLE
fix(responses): report why a bridged response is incomplete

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2166,7 +2166,6 @@ class LiteLLMCompletionResponsesConfig:
         if finish_reason == "content_filter":
             return IncompleteDetails(reason="content_filter")
         if finish_reason == "refusal":
-            # no matching reason in the Responses API enum
             return IncompleteDetails(reason=None)
         return None
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -59,6 +59,7 @@ from litellm.types.llms.openai import (
     ChatCompletionToolParamFunctionChunk,
     ChatCompletionUserMessage,
     GenericChatCompletionMessage,
+    IncompleteDetails,
     InputTokensDetails,
     OpenAIChatCompletionTextObject,
     OpenAIMcpServerTool,
@@ -2157,6 +2158,19 @@ class LiteLLMCompletionResponsesConfig:
             return "completed"
 
     @staticmethod
+    def _map_chat_completion_finish_reason_to_incomplete_details(
+        finish_reason: str | None,
+    ) -> IncompleteDetails | None:
+        if finish_reason == "length":
+            return IncompleteDetails(reason="max_output_tokens")
+        if finish_reason == "content_filter":
+            return IncompleteDetails(reason="content_filter")
+        if finish_reason == "refusal":
+            # no matching reason in the Responses API enum
+            return IncompleteDetails(reason=None)
+        return None
+
+    @staticmethod
     def _tool_call_id_from_responses_item(item_id: str | None, call_id: str | None) -> str:
         """Bedrock Mantle returns a non-unique, index-based ``call_id`` (``call_0``,
         ``call_1``, ... that resets every response) alongside a unique ``id``
@@ -2278,7 +2292,9 @@ class LiteLLMCompletionResponsesConfig:
             model=chat_completion_response.model,
             object="response",
             error=getattr(chat_completion_response, "error", None),
-            incomplete_details=getattr(chat_completion_response, "incomplete_details", None),
+            incomplete_details=LiteLLMCompletionResponsesConfig._map_chat_completion_finish_reason_to_incomplete_details(
+                finish_reason
+            ),
             instructions=getattr(chat_completion_response, "instructions", None),
             metadata=getattr(chat_completion_response, "metadata", {}),
             output=LiteLLMCompletionResponsesConfig._transform_chat_completion_choices_to_responses_output(

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -649,6 +649,82 @@ class TestLiteLLMCompletionResponsesConfig:
 
         assert responses_api_response.status == "incomplete"
 
+    @pytest.mark.parametrize(
+        ("finish_reason", "expected_status", "expected_reason"),
+        [
+            ("length", "incomplete", "max_output_tokens"),
+            ("content_filter", "incomplete", "content_filter"),
+            ("stop", "completed", None),
+        ],
+    )
+    def test_transform_chat_completion_response_populates_incomplete_details(
+        self, finish_reason, expected_status, expected_reason
+    ):
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="test-model",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason=finish_reason,
+                    index=0,
+                    message=Message(
+                        content="Truncated mid senten",
+                        role="assistant",
+                    ),
+                )
+            ],
+        )
+
+        responses_api_response = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+            request_input="this is a test",
+            responses_api_request={},
+            chat_completion_response=chat_completion_response,
+        )
+
+        assert responses_api_response.status == expected_status
+        if expected_reason is None:
+            assert responses_api_response.incomplete_details is None
+        else:
+            assert responses_api_response.incomplete_details is not None
+            assert responses_api_response.incomplete_details.reason == expected_reason
+
+    def test_transform_chat_completion_response_refusal_reports_content_filter_reason(self):
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="test-model",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="refusal",
+                    index=0,
+                    message=Message(
+                        content="",
+                        role="assistant",
+                    ),
+                )
+            ],
+        )
+
+        responses_api_response = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+            request_input="this is a test",
+            responses_api_request={},
+            chat_completion_response=chat_completion_response,
+        )
+
+        assert responses_api_response.status == "incomplete"
+        assert responses_api_response.incomplete_details is not None
+        assert responses_api_response.incomplete_details.reason == "content_filter"
+
+    def test_incomplete_details_helper_maps_unnormalized_refusal_to_null_reason(self):
+        details = LiteLLMCompletionResponsesConfig._map_chat_completion_finish_reason_to_incomplete_details(
+            "refusal"
+        )
+        assert details is not None
+        assert details.reason is None
+
     def test_tool_call_only_response_emits_no_null_text_message_item(self):
         """A tool-calls-only turn (message content None, e.g. from Anthropic)
         must not emit a message output item whose output_text has text null.

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_iterator_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_iterator_transformation.py
@@ -543,6 +543,19 @@ def test_completed_event_restores_usage_hidden_by_stream_options_none():
     assert completed.response.usage.output_tokens == 5
 
 
+def test_completed_event_reports_why_the_stream_was_cut_short():
+    iterator = _build_iterator([_chunk("partial answ"), _chunk("", finish_reason="length")])
+
+    events = list(iterator)
+
+    completed = next(
+        event for event in events if getattr(event, "type", None) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED
+    )
+    assert completed.response.status == "incomplete"
+    assert completed.response.incomplete_details is not None
+    assert completed.response.incomplete_details.reason == "max_output_tokens"
+
+
 def test_object_tool_call_arguments_stream_as_valid_json():
     """A provider that sends decoded object arguments must still stream valid JSON.
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- /v1/responses through the chat-completions bridge returns status incomplete with incomplete_details null
- clients read incomplete_details.reason to tell truncation apart from filtering
- both streaming and non-streaming responses hid the reason

How it solves it:

- map finish_reason length/content_filter to the matching reason
- refusal gets a null-reason object since the enum has no entry for it
- streaming response.completed picks this up from the same transform

## User Flow

Before: a developer using the OpenAI SDK against the gateway's /v1/responses for a model the gateway serves over a chat-completions backend gets truncation with no explanation

1. They send POST https://litellm-domain/v1/responses with input "List the three laws of robotics" and max_output_tokens: 8
2. The model stops at the token limit and the response arrives with "status": "incomplete"
3. Their retry logic reads response.incomplete_details.reason to decide whether to re-run with a bigger budget; it reads null and falls into the unknown-reason branch
4. With stream: true, the response.completed snapshot carries the same null

After: the same request says why it stopped

1. They send the same POST https://litellm-domain/v1/responses with input "List the three laws of robotics" and max_output_tokens: 8
2. The response arrives with "status": "incomplete" and "incomplete_details": {"reason": "max_output_tokens"}
3. Their retry logic sees max_output_tokens and re-runs with a bigger budget
4. With stream: true, response.completed carries the same reason

## Relevant issues

Self-contained. Noticed while reading the bridge after #37710 fixed the same gap in the other direction (responses-native → chat completions).

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: a one-file OpenAI-compatible server on 127.0.0.1:8123 whose POST /v1/chat/completions always finishes with finish_reason "length" (streaming sends the same finish_reason in the last chunk); the client calls `litellm.aresponses(model="openai/gpt-4o", use_chat_completions_api=True, api_base="http://127.0.0.1:8123/v1", ...)` twice, once non-streaming and once streaming, and prints status and incomplete_details. Real HTTP end to end, no mocks.

### Before (13df85cce)

1. `python client.py`
2. `stream=False status=incomplete incomplete_details=null`
3. `stream=True status=incomplete incomplete_details=null`

### After (e0871743b8)

1. `python client.py`
2. `stream=False status=incomplete incomplete_details={"reason": "max_output_tokens"}`
3. `stream=True status=incomplete incomplete_details={"reason": "max_output_tokens"}`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- refusal carries a null reason: the Responses API reason enum only has max_output_tokens and content_filter
