### PR TITLE
fix(ollama): handle optional initial_prompt_value and final_prompt_value in custom prompts (#39759)

### DIFF
--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -384,8 +384,10 @@ class OllamaConfig(BaseConfig):
             model_prompt_details: Final = custom_prompt_dict[model]
             ollama_prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
+                bos_token=model_prompt_details.get("bos_token", ""),
+                eos_token=model_prompt_details.get("eos_token", ""),
                 messages=messages,
             )
         elif text_completion_request:  # handle `/completions` requests

--- a/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
@@ -544,3 +544,47 @@ async def test_ollama_async_completion_inlines_remote_images_off_the_event_loop(
     assert response.choices[0].message.content == "Green"
     assert async_only_image_fetch.fetched == [image_url]
     assert captured["body"]["images"] == [async_only_image_fetch.base64_png]
+
+
+def test_ollama_transform_request_custom_prompt_optional_values():
+    config = OllamaConfig()
+    model = "custom-ollama-model"
+    messages = [{"role": "user", "content": "hello world"}]
+
+    litellm_params = {
+        "custom_prompt_dict": {
+            model: {
+                "roles": {
+                    "user": {"pre_message": "[INST] ", "post_message": " [/INST]"}
+                }
+            }
+        }
+    }
+    result = config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params={},
+        litellm_params=litellm_params,
+        headers={},
+    )
+    assert result["prompt"] == "[INST] hello world [/INST]"
+
+    litellm_params_initial_only = {
+        "custom_prompt_dict": {
+            model: {
+                "roles": {
+                    "user": {"pre_message": "Human: ", "post_message": "\n"}
+                },
+                "initial_prompt_value": "Instructions:\n",
+            }
+        }
+    }
+    result_initial = config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params={},
+        litellm_params=litellm_params_initial_only,
+        headers={},
+    )
+    assert result_initial["prompt"] == "Instructions:\nHuman: hello world\n"
+


### PR DESCRIPTION
## TLDR

Problem this solves:

- Custom prompt template without `initial_prompt_value` crashes with KeyError
- Custom prompt template without `final_prompt_value` crashes with KeyError
- Prevents requests to `ollama/` (and sister providers) from failing with 500

How it solves it:

- Uses `.get()` with safe empty string defaults for prompt values
- Uses `.get()` with safe empty dict defaults for roles
- Adds regression unit tests for custom prompt templates with optional values

## User Flow

Before: a user configuring a custom prompt template with only `roles` gets HTTP 500 APIConnectionError

1. User defines a custom prompt template for an Ollama model with `roles` (omitting `initial_prompt_value` and `final_prompt_value`).
2. User sends completion request to the model.
3. Server crashes with `KeyError: 'initial_prompt_value'` and returns HTTP 500.

After: the same request succeeds, applying roles with empty default prefix/suffix

1. User defines a custom prompt template for an Ollama model with `roles` (omitting `initial_prompt_value` and `final_prompt_value`).
2. User sends completion request to the model.
3. Request successfully formats prompt using roles and empty string defaults, returning HTTP 200.

## Relevant issues

Fixes #39759

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type

🐛 Bug Fix

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR