### PR TITLE
fix(router): restore compression inheritance when clearing overrides

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -763,6 +763,15 @@ def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> Pr
             if field in SPECIAL_MODEL_INFO_PARAMS and getattr(updated_patch.litellm_params, field) is None:
                 merged_litellm_params.pop(field, None)
                 merged_model_info.pop(field, None)
+            elif (
+                field
+                in (
+                    "auto_router_routing_compression",
+                    "auto_router_model_compression",
+                )
+                and getattr(updated_patch.litellm_params, field) is None
+            ):
+                merged_litellm_params.pop(field, None)
     if updated_patch.model_info:
         for field in updated_patch.model_info.model_fields_set:
             if field in SPECIAL_MODEL_INFO_PARAMS and getattr(updated_patch.model_info, field) is None:

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -3,7 +3,7 @@ import asyncio
 import contextlib
 import json
 from collections.abc import Mapping
-from typing import Dict, Optional
+from typing import Dict, Final, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -3288,6 +3288,99 @@ def _build_db_model_with_pricing():
         ),
         model_info=ModelInfo(id="dep-pricing-0"),
     )
+
+
+class TestUpdateDBModelCompression:
+    @pytest.mark.parametrize(
+        "compression_patch, expected",
+        [
+            (
+                {},
+                {
+                    "auto_router_routing_compression": "routing-compressor",
+                    "auto_router_model_compression": "model-compressor",
+                },
+            ),
+            ({"auto_router_routing_compression": None}, {"auto_router_model_compression": "model-compressor"}),
+            ({"auto_router_model_compression": None}, {"auto_router_routing_compression": "routing-compressor"}),
+            (
+                {"auto_router_routing_compression": "none", "auto_router_model_compression": "none"},
+                {"auto_router_routing_compression": "none", "auto_router_model_compression": "none"},
+            ),
+            (
+                {
+                    "auto_router_routing_compression": "new-compressor",
+                    "auto_router_model_compression": "new-compressor",
+                },
+                {
+                    "auto_router_routing_compression": "new-compressor",
+                    "auto_router_model_compression": "new-compressor",
+                },
+            ),
+        ],
+    )
+    def test_compression_patch_preserves_omissions_and_explicit_choices(
+        self, monkeypatch: pytest.MonkeyPatch, compression_patch: dict[str, str | None], expected: dict[str, str]
+    ):
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import decrypt_value_helper
+        from litellm.proxy.management_endpoints.model_management_endpoints import update_db_model
+
+        monkeypatch.setenv("LITELLM_SALT_KEY", "synthetic-compression-salt")
+        result: Final = update_db_model(
+            db_model=Deployment(
+                model_name="synthetic-router",
+                litellm_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    auto_router_routing_compression=encrypt_value_helper("routing-compressor"),
+                    auto_router_model_compression=encrypt_value_helper("model-compressor"),
+                ),
+                model_info=ModelInfo(id="compression-router"),
+            ),
+            updated_patch=updateDeployment.model_validate({"litellm_params": compression_patch}),
+        )
+        params: Final = json.loads(result["litellm_params"])
+        assert {
+            key: decrypt_value_helper(value=val, key=key)
+            for key, val in params.items()
+            if key in ("auto_router_routing_compression", "auto_router_model_compression")
+        } == expected
+
+    def test_explicit_compression_clear_removes_both_saved_overrides(self):
+        from litellm.proxy.guardrails.auto_router_compression import policy_from_litellm_params
+        from litellm.proxy.management_endpoints.model_management_endpoints import update_db_model
+
+        db_model: Final = Deployment(
+            model_name="synthetic-router",
+            litellm_params=LiteLLM_Params(
+                model="auto_router/complexity_router",
+                auto_router_routing_compression="routing-compressor",
+                auto_router_model_compression="model-compressor",
+                api_base="http://127.0.0.1:9999/v1",
+                temperature=0,
+            ),
+            model_info=ModelInfo(id="compression-router", team_id="synthetic-team"),
+        )
+        result: Final = update_db_model(
+            db_model=db_model,
+            updated_patch=updateDeployment.model_validate(
+                {
+                    "litellm_params": {
+                        "auto_router_routing_compression": None,
+                        "auto_router_model_compression": None,
+                        "api_base": None,
+                    },
+                    "model_info": {"team_id": None},
+                }
+            ),
+        )
+
+        params: Final = json.loads(result["litellm_params"])
+        assert "auto_router_routing_compression" not in params
+        assert "auto_router_model_compression" not in params
+        assert policy_from_litellm_params(params) is None
+        assert params["api_base"] == "http://127.0.0.1:9999/v1"
+        assert params["temperature"] == 0
+        assert json.loads(result["model_info"])["team_id"] == "synthetic-team"
 
 
 class TestUpdateDBModelClearPricing:

--- a/ui/litellm-dashboard/src/components/add_model/CompressionControls.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/CompressionControls.tsx
@@ -20,8 +20,7 @@ const NONE_OPTION: SearchSelectOption = { label: "None (no compression)", value:
 
 const CompressionControls: React.FC<CompressionControlsProps> = ({ value, onChange }) => {
   const { routing, sameAsRouting, model } = value;
-  const onRoutingChange = (newRouting: string | undefined) =>
-    onChange({ ...value, routing: newRouting, sameAsRouting: newRouting === undefined ? true : sameAsRouting });
+  const onRoutingChange = (newRouting: string | undefined) => onChange({ ...value, routing: newRouting });
   const onSameAsRoutingChange = (newSameAsRouting: boolean) => onChange({ ...value, sameAsRouting: newSameAsRouting });
   const onModelChange = (newModel: string | undefined) => onChange({ ...value, model: newModel });
 

--- a/ui/litellm-dashboard/src/components/add_model/buildAutoRouterCompression.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/buildAutoRouterCompression.test.ts
@@ -1,9 +1,22 @@
 import {
   buildAutoRouterCompressionParams,
+  buildAutoRouterCompressionPatch,
   DEFAULT_AUTO_ROUTER_COMPRESSION,
   hydrateAutoRouterCompression,
   NO_COMPRESSION,
 } from "./buildAutoRouterCompression";
+
+describe("buildAutoRouterCompressionPatch", () => {
+  it.each([
+    {},
+    { auto_router_routing_compression: "routing-compressor" },
+    { auto_router_model_compression: "model-compressor" },
+    { auto_router_routing_compression: "none", auto_router_model_compression: "none" },
+    { auto_router_routing_compression: "routing-compressor", auto_router_model_compression: "model-compressor" },
+  ])("should preserve the exact stored fields on an untouched save: %j", (stored) => {
+    expect(buildAutoRouterCompressionPatch(hydrateAutoRouterCompression(stored), stored)).toEqual({});
+  });
+});
 
 describe("buildAutoRouterCompressionParams", () => {
   it("omits both keys when routing was never configured", () => {

--- a/ui/litellm-dashboard/src/components/add_model/buildAutoRouterCompression.ts
+++ b/ui/litellm-dashboard/src/components/add_model/buildAutoRouterCompression.ts
@@ -30,6 +30,8 @@ export interface AutoRouterCompressionLitellmParams {
   auto_router_model_compression?: string;
 }
 
+type AutoRouterCompressionPatch = Partial<Record<keyof AutoRouterCompressionLitellmParams, string | null>>;
+
 export const DEFAULT_AUTO_ROUTER_COMPRESSION: AutoRouterCompressionState = {
   routing: undefined,
   sameAsRouting: true,
@@ -66,4 +68,19 @@ export const hydrateAutoRouterCompression = (litellmParams: {
   const model = storedModel ?? NO_COMPRESSION;
   const sameAsRouting = model === routing;
   return { routing, sameAsRouting, model: sameAsRouting ? undefined : model };
+};
+
+export const buildAutoRouterCompressionPatch = (
+  state: AutoRouterCompressionState,
+  stored: AutoRouterCompressionPatch,
+): AutoRouterCompressionPatch => {
+  const initial = hydrateAutoRouterCompression(stored);
+  const modelUnchanged = state.sameAsRouting || state.model === initial.model;
+  if (state.routing === initial.routing && state.sameAsRouting === initial.sameAsRouting && modelUnchanged) {
+    return {};
+  }
+  if (state.routing === undefined) {
+    return { auto_router_routing_compression: null, auto_router_model_compression: null };
+  }
+  return buildAutoRouterCompressionParams(state);
 };

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.integration.test.tsx
@@ -1064,6 +1064,55 @@ describe("EditAutoRouterModal prompt compression", () => {
       />,
     );
 
+  it("should clear both saved compression overrides when inheritance is selected", async () => {
+    const user = userEvent.setup();
+    renderWithStoredCompression({
+      auto_router_routing_compression: "routing-compressor",
+      auto_router_model_compression: "model-compressor",
+    });
+
+    await user.click(await screen.findByText("Advanced: Compression"));
+    await user.click(screen.getAllByRole("button", { name: "Clear", exact: true })[0]);
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(modelPatchUpdateCall).toHaveBeenCalledWith(
+        "token",
+        expect.objectContaining({
+          litellm_params: expect.objectContaining({
+            model: "auto_router/complexity_router",
+            auto_router_routing_compression: null,
+            auto_router_model_compression: null,
+          }),
+        }),
+        "auto-1",
+      ),
+    );
+  });
+
+  it("should discard a cancelled clear and preserve compression when the saved choice is restored", async () => {
+    const user = userEvent.setup();
+    const stored = { auto_router_routing_compression: "none", auto_router_model_compression: "model-compressor" };
+    const view = renderWithStoredCompression(stored);
+
+    await user.click(await screen.findByText("Advanced: Compression"));
+    await user.click(screen.getAllByRole("button", { name: "Clear", exact: true })[0]);
+    await user.click(screen.getByRole("button", { name: "Cancel", exact: true }));
+    expect(modelPatchUpdateCall).not.toHaveBeenCalled();
+    view.unmount();
+
+    renderWithStoredCompression(stored);
+    await user.click(await screen.findByText("Advanced: Compression"));
+    expect(screen.getByRole("combobox", { name: "Routing decision compression" })).toHaveValue("None (no compression)");
+    await user.click(screen.getAllByRole("button", { name: "Clear", exact: true })[0]);
+    await user.click(screen.getByRole("combobox", { name: "Routing decision compression" }));
+    await user.click(screen.getByRole("option", { name: "None (no compression)" }));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedLitellmParams()).toMatchObject(stored);
+  });
+
   it("leaves both compression keys out of an untouched save when none were stored", async () => {
     const user = userEvent.setup();
     renderWithStoredCompression();
@@ -1075,18 +1124,24 @@ describe("EditAutoRouterModal prompt compression", () => {
     expect(savedLitellmParams()).not.toHaveProperty("auto_router_model_compression");
   });
 
-  it("preserves a stored same-as-routing compression through an untouched open-and-save", async () => {
+  it.each([
+    { auto_router_routing_compression: "headroom-a", auto_router_model_compression: "headroom-a" },
+    { auto_router_routing_compression: "routing-compressor" },
+    { auto_router_model_compression: "model-compressor" },
+  ])("should preserve the exact stored compression fields through an untouched save: %j", async (stored) => {
     const user = userEvent.setup();
-    renderWithStoredCompression({
-      auto_router_routing_compression: "headroom-a",
-      auto_router_model_compression: "headroom-a",
-    });
+    renderWithStoredCompression(stored);
 
     await user.click(await screen.findByRole("button", { name: /save changes/i }));
 
     await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
-    expect(savedLitellmParams()?.auto_router_routing_compression).toBe("headroom-a");
-    expect(savedLitellmParams()?.auto_router_model_compression).toBe("headroom-a");
+    expect(
+      Object.fromEntries(
+        Object.entries(savedLitellmParams()).filter(
+          ([key]) => key === "auto_router_routing_compression" || key === "auto_router_model_compression",
+        ),
+      ),
+    ).toEqual(stored);
   });
 
   it("shows a stored different-compression choice as Use a different compression, not Same", async () => {

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -44,7 +44,7 @@ import { KeywordTierRule } from "../add_model/KeywordTierRules";
 import { DEFAULT_MATCH_THRESHOLD } from "../add_model/SemanticKeywordMatching";
 import {
   type AutoRouterCompressionState,
-  buildAutoRouterCompressionParams,
+  buildAutoRouterCompressionPatch,
   DEFAULT_AUTO_ROUTER_COMPRESSION,
   hydrateAutoRouterCompression,
 } from "../add_model/buildAutoRouterCompression";
@@ -679,7 +679,7 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
         ...modelData.litellm_params,
         complexity_router_config: updatedConfig,
         complexity_router_default_model: defaultModel,
-        ...buildAutoRouterCompressionParams(autoRouterCompression),
+        ...buildAutoRouterCompressionPatch(autoRouterCompression, modelData.litellm_params ?? {}),
       };
       const updatedModelInfo = {
         ...modelData.model_info,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cleared compression choices return after saving an auto-router.
- Clearing and restoring routing loses a different model compressor.

How it solves it:

- Explicitly clear both saved compression overrides.
- Preserve untouched fields and temporary model-compression choices.

## User Flow

Before: clearing compression keeps the old overrides active.

1. Open `/ui/models-and-endpoints/`, choose an auto-router, and select Edit Auto Router.
2. Expand Advanced: Compression, clear Routing decision, and save.
3. Reopen the editor: the old choices return.
4. Send a request with request-level compression: the saved override still wins.

After: clearing compression restores inheritance.

1. Open `/ui/models-and-endpoints/`, choose an auto-router, and select Edit Auto Router.
2. Expand Advanced: Compression, clear Routing decision, and save.
3. Reopen the editor: Routing decision remains unset.
4. Send a request with request-level compression: that compression applies.

## Relevant issues

## Linear ticket

Resolves LIT-7643

## Pre-Submission checklist

- [x] I have added meaningful tests.
- [x] The focused test files pass locally: 141 UI tests and 244 backend/policy tests.
- [x] My PR passes all required CI/CD checks.
- [x] The scope is isolated to compression inheritance and preservation.
- [x] Greptile has independently posted [5/5 for the current head](https://github.com/BerriAI/litellm/pull/40839#issuecomment-5644206290).

## Screenshots / Proof of Fix

Executed against an isolated dashboard, real proxy and PostgreSQL, with synthetic guardrails and a deterministic local upstream. The router starts with routing compression `none` and model compression `model-compressor`; requests specify `request-compressor`. Detailed qualification artifacts are retained locally. No external provider behavior or billing claim is made.

### Before (e88ba94da5aa6eb07f62aa1ad11ab4ea51832822)

1. Clear Routing decision in the editor and save. The actual `PATCH /model/compression-proof-router/update` still sends `none` and `model-compressor`.
2. Send both compression fields as JSON `null` directly to the same endpoint. It returns 200, but a fresh model read still contains both saved values.
3. Send `POST /v1/chat/completions` with `guardrails: ["request-compressor"]`. It returns 200; the captured model prompt contains `[model-compressor]`.

### After (7e5cf9d7e7d07fd270835ab7e1408b4d1d4604e7)

1. Clear Routing decision in the editor and save. The actual PATCH sends both compression fields as JSON `null`.
2. Read the model and persisted record. Both compression keys are absent; reopen and refresh retain the unset routing choice.
3. Send the same chat request. It returns 200; only `request-compressor` runs, and the captured model prompt contains `[request-compressor]`.

Additional controls cover untouched and one-sided settings, explicit `none`, same/different model choices, cancel, clear/restore, create omission, encrypted parameters, and restricted-role rejection. Reintroducing either original faulty branch fails its payload or persistence assertion. Independent review found the distinct-compressor restore edge case, which is fixed and rechecked.

CI executed the changed editor suite (55 tests), compression builder (18 tests), create suite (68 tests), all six backend regression cases and all 30 compression-policy cases. The related UI run passed 1,551 tests with four existing expected failures. [UI CI](https://github.com/BerriAI/litellm/actions/runs/34678125081) and [backend CI](https://github.com/BerriAI/litellm/actions/runs/34678125189) are green.

## Type

Bug Fix

## Caveats

### Low

- Local schema regeneration reports unrelated existing description whitespace drift.
- The same drift reproduces with the unmodified backend.
- CI schema sync, lint, UI build and tests pass.

## Final Attestation

- [x] Regression assertions cover the scoped clear and preservation contracts.
