### PR TITLE
feat(model-catalog): add bedrock_mantle/us-gov-west-1/openai.gpt-5.6-sol

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -60369,6 +60369,40 @@
         "output_cost_per_token": 1.584e-05,
         "output_cost_per_token_above_272k_tokens": 2.376e-05
     },
+    "bedrock_mantle/us-gov-west-1/openai.gpt-5.6-sol": {
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "use_openai_responses_path": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "input_cost_per_token": 6.6e-06,
+        "input_cost_per_token_above_272k_tokens": 1.32e-05,
+        "cache_creation_input_token_cost": 8.25e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.65e-05,
+        "cache_read_input_token_cost": 6.6e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1.32e-06,
+        "output_cost_per_token": 3.96e-05,
+        "output_cost_per_token_above_272k_tokens": 5.94e-05
+    },
     "bedrock_mantle/us-gov-west-1/openai.gpt-5.6-luna": {
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -60369,6 +60369,40 @@
         "output_cost_per_token": 1.584e-05,
         "output_cost_per_token_above_272k_tokens": 2.376e-05
     },
+    "bedrock_mantle/us-gov-west-1/openai.gpt-5.6-sol": {
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "use_openai_responses_path": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "input_cost_per_token": 6.6e-06,
+        "input_cost_per_token_above_272k_tokens": 1.32e-05,
+        "cache_creation_input_token_cost": 8.25e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.65e-05,
+        "cache_read_input_token_cost": 6.6e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1.32e-06,
+        "output_cost_per_token": 3.96e-05,
+        "output_cost_per_token_above_272k_tokens": 5.94e-05
+    },
     "bedrock_mantle/us-gov-west-1/openai.gpt-5.6-luna": {
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,


### PR DESCRIPTION
## Summary

Closes #40102 (remaining piece).

`#40581` added `openrouter/openai/gpt-5.6-sol`; the issue's last comment noted that `bedrock_mantle/us-gov-west-1/openai.gpt-5.6-sol` was still missing. This PR adds it.

The entry follows the same structure as the existing `us-gov-west-1` siblings (`gpt-5.6-terra`, `gpt-5.6-luna`):
- `mode: responses`, `use_openai_responses_path: true`
- Same capability flags as `bedrock_mantle/openai.gpt-5.6-sol` (vision, reasoning, web search, function calling, prompt caching, response schema)
- Pricing derived from standard sol costs using the same 1.2× GovCloud premium applied to the terra sibling

Both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json` updated.