### PR TITLE
fix(gpt5): gate reasoning_effort='none' with opt-out check in OpenAIGPT5Config

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -300,6 +300,20 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
                         message=(f"reasoning_effort={effective_effort} is not supported for this model."),
                         status_code=400,
                     )
+        elif effective_effort == "none":
+            # none is opt-out: unknown models pass through; only block when
+            # the model map explicitly sets supports_none_reasoning_effort=false.
+            # gpt-5 and gpt-5-mini are both marked supports_none_reasoning_effort=false
+            # and OpenAI returns 400 for none on those models.
+            if self._is_reasoning_effort_level_explicitly_disabled(model, effective_effort):
+                if litellm.drop_params or drop_params:
+                    non_default_params.pop("reasoning_effort", None)
+                    optional_params.pop("reasoning_effort", None)
+                else:
+                    raise litellm.utils.UnsupportedParamsError(
+                        message=(f"reasoning_effort={effective_effort} is not supported for this model."),
+                        status_code=400,
+                    )
 
         ################################################################
         # max_tokens is not supported for gpt-5 models on OpenAI API


### PR DESCRIPTION
## Summary

Adds an explicit `elif effective_effort == "none":` gate to `OpenAIGPT5Config.map_openai_params` that uses the same opt-out pattern as the existing `minimal/low` gate: unknown models pass through; only block when the model map explicitly sets `supports_none_reasoning_effort=false`.

**Why this matters:** `gpt-5` and `gpt-5-mini` are both marked `supports_none_reasoning_effort=false` in the model cost map, but before this change passing `reasoning_effort="none"` to those models would silently pass through and get rejected with an opaque 400 from OpenAI instead of a clear `UnsupportedParamsError`.

**Before:** `reasoning_effort="none"` passed through to OpenAI for gpt-5/gpt-5-mini → 400 from provider.

**After:** `reasoning_effort="none"` raises `UnsupportedParamsError(status_code=400)` before the request is sent, or drops the param when `drop_params=True`.

The gate mirrors the `minimal/low` block exactly — uses `_is_reasoning_effort_level_explicitly_disabled` (opt-out: only blocks when map sets flag to `False`, unknown models pass through).