### PR TITLE
fix(anthropic): route custom-base openai/ through chat/completions on…

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -77,7 +77,10 @@ def _points_at_openai_backend(api_base: str | None) -> bool:
     """
     if not api_base:
         return True
-    return "api.openai.com" in api_base
+    from urllib.parse import urlparse
+
+    parsed = urlparse(api_base if "://" in api_base else f"//{api_base}")
+    return (parsed.hostname or "").lower() == "api.openai.com"
 
 
 def _should_route_to_responses_api(

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -68,10 +68,23 @@ def _responses_mode_is_lost_by_prefix_strip(
     )
 
 
+def _points_at_openai_backend(api_base: str | None) -> bool:
+    """Whether api_base is unset or targets api.openai.com rather than a self-hosted backend.
+
+    The ``openai/`` prefix is also how OpenAI-compatible servers (vLLM, llama.cpp, SGLang, ...)
+    are declared. Those set a custom api_base and do not implement the Responses API, so bridging
+    /v1/messages to it there breaks multimodal requests.
+    """
+    if not api_base:
+        return True
+    return "api.openai.com" in api_base
+
+
 def _should_route_to_responses_api(
     custom_llm_provider: str | None,
     requested_model: str | None = None,
     resolved_model: str | None = None,
+    api_base: str | None = None,
 ) -> bool:
     """Return True when the request should use the Responses API path.
 
@@ -81,7 +94,7 @@ def _should_route_to_responses_api(
     if litellm.use_chat_completions_url_for_anthropic_messages:
         return False
     if custom_llm_provider in _RESPONSES_API_PROVIDERS:
-        return True
+        return _points_at_openai_backend(api_base)
     if custom_llm_provider is None or requested_model is None or resolved_model is None:
         return False
     return _responses_mode_is_lost_by_prefix_strip(requested_model, resolved_model, custom_llm_provider)
@@ -578,7 +591,7 @@ def anthropic_messages_handler(
         )
     if anthropic_messages_provider_config is None:
         # Route to Responses API for OpenAI / Azure, chat/completions for everything else.
-        if _should_route_to_responses_api(custom_llm_provider, original_model, model):
+        if _should_route_to_responses_api(custom_llm_provider, original_model, model, dynamic_api_base or api_base):
             return LiteLLMMessagesToResponsesAPIHandler.anthropic_messages_handler(
                 max_tokens=max_tokens,
                 messages=messages,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -137,6 +137,27 @@ def test_anthropic_experimental_pass_through_messages_handler_dynamic_api_key_an
         assert mock_completion.call_args.kwargs["custom_key"] == "custom_value"
 
 
+@pytest.mark.parametrize(
+    "api_base, expected",
+    [
+        (None, True),
+        ("https://api.openai.com/v1", True),
+        ("http://localhost:8000/v1", False),
+        ("http://vllm-host:8000/v1", False),
+    ],
+)
+def test_should_route_to_responses_api_considers_api_base_for_openai(api_base, expected):
+    """Regression test for #40780. A self-hosted OpenAI-compatible backend declared as
+    ``openai/<model>`` with a custom api_base must not be routed to the OpenAI Responses API
+    (which reshapes images into ``input_image`` items the backend rejects); only real OpenAI
+    (api_base unset or api.openai.com) keeps the Responses API path."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        _should_route_to_responses_api,
+    )
+
+    assert _should_route_to_responses_api("openai", "openai/model", "model", api_base) is expected
+
+
 @pytest.mark.asyncio
 async def test_anthropic_messages_sanitizes_empty_text_blocks_before_dispatch():
     """Regression test for #22930.  The unified /v1/messages path must

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -142,20 +142,50 @@ def test_anthropic_experimental_pass_through_messages_handler_dynamic_api_key_an
     [
         (None, True),
         ("https://api.openai.com/v1", True),
+        ("api.openai.com", True),
+        ("HTTPS://API.OPENAI.COM/v1", True),
         ("http://localhost:8000/v1", False),
         ("http://vllm-host:8000/v1", False),
+        ("https://api.openai.com.evil.example/v1", False),
+        ("https://not-api.openai.com.internal/v1", False),
     ],
 )
 def test_should_route_to_responses_api_considers_api_base_for_openai(api_base, expected):
     """Regression test for #40780. A self-hosted OpenAI-compatible backend declared as
     ``openai/<model>`` with a custom api_base must not be routed to the OpenAI Responses API
     (which reshapes images into ``input_image`` items the backend rejects); only real OpenAI
-    (api_base unset or api.openai.com) keeps the Responses API path."""
+    (api_base unset or the api.openai.com host) keeps the Responses API path. Hostname matching
+    is normalized, so case variants resolve to OpenAI while lookalike hosts that merely contain
+    the string do not."""
     from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
         _should_route_to_responses_api,
     )
 
     assert _should_route_to_responses_api("openai", "openai/model", "model", api_base) is expected
+
+
+def test_openai_custom_api_base_forwards_messages_to_chat_completions():
+    """Regression test for #40780 at the request-path level: driving the real handler, an
+    ``openai/`` deployment with a custom api_base must forward /v1/messages to chat/completions
+    (``litellm.completion``) rather than the Responses API, guarding the api_base wiring at the
+    call site, not just the routing helper."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages_handler,
+    )
+
+    with patch("litellm.completion") as mock_completion:  # test-quality-ok: routes via real handler; no injection seam
+        try:
+            anthropic_messages_handler(
+                max_tokens=100,
+                messages=[{"role": "user", "content": "Hello, how are you?"}],
+                model="openai/my-local-model",
+                api_base="http://localhost:8000/v1",
+                api_key="sk-noauth",
+            )
+        except (ValueError, TypeError, AttributeError) as e:
+            print(f"Error: {e}")
+        mock_completion.assert_called_once()
+        assert mock_completion.call_args.kwargs["api_base"] == "http://localhost:8000/v1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- `openai/` models with a custom `api_base` break images on `/v1/messages`
- self-hosted OpenAI-compatible servers get bridged to the Responses API
- image blocks become `input_image`, which those backends reject

How it solves it:

- route `openai/` with a custom `api_base` through chat/completions
- keep the Responses API only for real OpenAI (`api_base` unset or `api.openai.com`)
- matches the existing `hosted_vllm/` behavior

## User Flow

Before: a developer running a self-hosted OpenAI-compatible server (vLLM, declared as `openai/<model>` with a custom `api_base`) cannot send images through `/v1/messages`

1. They POST https://their-gateway/v1/messages with an anthropic-format message whose content includes one image block
2. The call returns HTTP 400 with hundreds of validation errors about `input_image` and "Input should be a valid string"
3. The same image sent to https://their-gateway/v1/chat/completions returns 200 in a few seconds

After: the same `/v1/messages` image request succeeds

1. They POST the same request to https://their-gateway/v1/messages
2. It returns 200 with a normal assistant message that describes the image
3. Behavior now matches https://their-gateway/v1/chat/completions

## Relevant issues

Fixes #40780

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all checks locally (`make lint` is green, including the ruff/basedpyright/test-quality budget gates)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced end to end against a real OpenAI-compatible backend (`llama-server` from llama.cpp serving the vision model SmolVLM), declared with the `openai/` prefix and a custom `api_base`, exactly as in the issue.

Shared setup (config):

```yaml
model_list:
  - model_name: local-vlm
    litellm_params:
      model: openai/SmolVLM-256M-Instruct
      api_base: http://127.0.0.1:8000/v1
      api_key: os.environ/BACKEND_API_KEY
```

Shared payload (the same request in both runs):

```bash
curl -s http://localhost:4001/v1/messages \
  -H "Authorization: Bearer sk-1234" \
  -H 'anthropic-version: 2023-06-01' \
  -H 'Content-Type: application/json' \
  -d '{"model":"local-vlm","max_tokens":32,"messages":[{"role":"user","content":[
       {"type":"text","text":"What is here?"},
       {"type":"image","source":{"type":"base64","media_type":"image/png",
        "data":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="}}]}]}'
```

### Before (9a715df)

1. Run the request above. The gateway bridges it to the Responses API and posts to the backend's `/v1/responses` with the image reshaped as `input_image`:

```
POST http://127.0.0.1:8000/v1/responses
{'model': 'SmolVLM-256M-Instruct',
 'input': [{'type': 'message', 'role': 'user', 'content': [
   {'type': 'input_text',  'text': 'What is here?'},
   {'type': 'input_image', 'image_url': 'data:image/png;base64,...'}]}]}
```

2. The Anthropic response id comes back as `resp_...` (Responses API). On a strict backend such as vLLM this same `input_image` shape is rejected with HTTP 400 and the 248 validation errors from the issue; llama.cpp is lenient and accepts it, so the misroute is silent there.

### After (8b00177)

1. Run the same request. The gateway now routes through chat/completions and posts to the backend's `/v1/chat/completions` with the image kept as `image_url`.
2. The Anthropic response id comes back as `chatcmpl-...` and the body is a normal assistant message describing the image:

```json
{"id":"chatcmpl-...","type":"message","role":"assistant","model":"local-vlm",
 "content":[{"type":"text","text":" This image is a photograph of a red background with white text..."}],
 "stop_reason":"end_turn"}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- a self-hosted backend that genuinely implements the Responses API, declared as `openai/` with a custom `api_base`, now defaults to chat/completions
- workaround exists in spirit: `litellm.use_chat_completions_url_for_anthropic_messages` already forces chat/completions globally
- cleaner follow-up: an explicit per-deployment opt-in via `model_info.supported_endpoints`, so such a backend can request the Responses path

### Low

- the related `/v1/responses/input_tokens` 405 probe on these models shares the same assumption but is a separate code path, left out of scope to keep this change isolated

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR