### PR TITLE
fix(responses): preserve explicit websocket API keys

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -2258,6 +2258,7 @@ async def _aresponses_websocket(
     resolved_api_base: Final = dynamic_api_base or litellm_params.api_base or litellm.api_base or None
     resolved_api_key: Final = (
         dynamic_api_key
+        or api_key
         or litellm_params.api_key
         or litellm.api_key
         or litellm.openai_key

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -2473,6 +2473,53 @@ class TestWebSocketChunkTypes:
         assert messages[0]["content"][0]["text"] == "Part 1Part 2"
 
 
+class TestResponsesWebSocketCredentials:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "explicit_key,global_key,expected_key",
+        [
+            ("deployment-key", None, "deployment-key"),
+            ("deployment-key", "global-key", "deployment-key"),
+            (None, "global-key", "global-key"),
+        ],
+    )
+    async def test_openai_websocket_authorization(self, monkeypatch, explicit_key, global_key, expected_key):
+        from unittest.mock import AsyncMock, patch
+
+        import litellm
+        from litellm.responses import main as responses_main
+
+        monkeypatch.setattr(litellm, "api_key", global_key)
+        monkeypatch.setattr(litellm, "openai_key", None)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("LITELLM_RUST", "false")
+        captured_headers = []
+
+        class FakeConnect:
+            def __init__(self, url, **kwargs):
+                captured_headers.append(kwargs["additional_headers"])
+
+            async def __aenter__(self):
+                raise RuntimeError("stop at upstream handshake")
+
+            async def __aexit__(self, *args):
+                pass
+
+        websocket = MagicMock()
+        websocket.close = AsyncMock()
+        with patch("websockets.connect", FakeConnect):
+            await responses_main._aresponses_websocket.__wrapped__(
+                model="gpt-6-astra",
+                websocket=websocket,
+                api_key=explicit_key,
+                api_base="https://upstream.invalid/v1",
+                litellm_logging_obj=MagicMock(),
+            )
+
+        assert len(captured_headers) == 1
+        assert captured_headers[0]["Authorization"] == f"Bearer {expected_key}"
+
+
 class TestNativeWebSocketUrlConstruction:
     """Test that native WebSocket URLs include the model query parameter.
 

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -2484,6 +2484,8 @@ class TestResponsesWebSocketCredentials:
         ],
     )
     async def test_openai_websocket_authorization(self, monkeypatch, explicit_key, global_key, expected_key):
+        from asyncio import Future, get_running_loop
+        from typing import Final
         from unittest.mock import AsyncMock, patch
 
         import litellm
@@ -2493,11 +2495,11 @@ class TestResponsesWebSocketCredentials:
         monkeypatch.setattr(litellm, "openai_key", None)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.setenv("LITELLM_RUST", "false")
-        captured_headers = []
+        captured_authorization: Final[Future[str]] = get_running_loop().create_future()
 
         class FakeConnect:
             def __init__(self, url, **kwargs):
-                captured_headers.append(kwargs["additional_headers"])
+                captured_authorization.set_result(kwargs["additional_headers"]["Authorization"])
 
             async def __aenter__(self):
                 raise RuntimeError("stop at upstream handshake")
@@ -2505,7 +2507,7 @@ class TestResponsesWebSocketCredentials:
             async def __aexit__(self, *args):
                 pass
 
-        websocket = MagicMock()
+        websocket: Final = MagicMock()
         websocket.close = AsyncMock()
         with patch("websockets.connect", FakeConnect):
             await responses_main._aresponses_websocket.__wrapped__(
@@ -2516,8 +2518,8 @@ class TestResponsesWebSocketCredentials:
                 litellm_logging_obj=MagicMock(),
             )
 
-        assert len(captured_headers) == 1
-        assert captured_headers[0]["Authorization"] == f"Bearer {expected_key}"
+        assert captured_authorization.done()
+        assert captured_authorization.result() == f"Bearer {expected_key}"
 
 
 class TestNativeWebSocketUrlConstruction:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Responses WebSocket drops explicit deployment API keys
- Upstream rejects the handshake and clients lose their stream

How it solves it:

- Preserve the explicit key before process-level fallbacks
- Verify authorization at the upstream WebSocket boundary

## User Flow

Before: a developer using a configured OpenAI-compatible deployment loses the WebSocket connection before completion

1. The admin configures a bare model name with `custom_llm_provider: openai`, an upstream base URL, and a deployment API key
2. The developer connects to `ws://127.0.0.1:14001/v1/responses` using the proxy key and sends the `response.create` payload below
3. The connection closes with code 1011 and an upstream HTTP 401 before `response.completed`

After: the same request streams to completion

1. The admin configures a bare model name with `custom_llm_provider: openai`, an upstream base URL, and a deployment API key
2. The developer connects to `ws://127.0.0.1:14001/v1/responses` using the proxy key and sends the `response.create` payload below
3. The client receives `response.completed`

## Relevant issues

Refreshes #34253 against the current default branch, where the original PR has merge conflicts. The one-line fix is credited to its author in the commit trailer. This PR replaces the old handler mock with a transport-boundary regression test and adds real upstream before/after evidence

The regression cases cover an explicit key with no global key, an explicit key overriding a global key, and the existing global fallback when no explicit key is supplied. All 109 tests in `tests/test_litellm/responses/test_responses_websocket_all_providers.py` pass. Before applying the fix, both explicit-key cases fail and the fallback case passes

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

Validation at `4ac90ba44e006af1bf8c58f410d583e38347f7c2`: 86 successful checks, no failures or pending checks, and one stage-mirror E2E job skipped by the workflow's fork restriction. Codecov reports all modified and coverable lines covered

Greptile scored 5/5 and resolved its only thread after the test capture was corrected. Bugbot reviewed this tip and found no new issues. All committers have signed the CLA

Veria reviewed this tip after the PR became ready for review and passed with no security issues found

## Screenshots / Proof of Fix

Both runs used an isolated local proxy and the same real upstream supporting native Responses WebSocket, with a valid deployment key and no process-level OpenAI key. Credentials remained in environment variables and are omitted here. The live deployment was not modified

Configuration, with the upstream's bare model ID retained:

```yaml
model_list:
  - model_name: ws-test
    litellm_params:
      model: gpt-6-astra
      custom_llm_provider: openai
      api_base: os.environ/WS_QA_UPSTREAM_BASE
      api_key: os.environ/WS_QA_UPSTREAM_KEY
general_settings:
  master_key: os.environ/WS_QA_MASTER_KEY
```

Start each checkout with the same environment and config:

```sh
CONFIG_FILE_PATH=/tmp/litellm-ws-qa-config.yaml LITELLM_RUST=false \
  python -m uvicorn litellm.proxy.proxy_server:app \
  --host 127.0.0.1 --port 14001
```

Send the same request in both runs:

```python
import asyncio, json, os
import websockets

async def main():
    try:
        async with websockets.connect(
            "ws://127.0.0.1:14001/v1/responses",
            additional_headers={"Authorization": "Bearer " + os.environ["WS_QA_MASTER_KEY"]},
        ) as ws:
            await ws.send(json.dumps({
                "type": "response.create",
                "model": "ws-test",
                "input": [{"role": "user", "content": [
                    {"type": "input_text", "text": "Reply with OK only."}
                ]}],
                "max_output_tokens": 64,
            }))
            while True:
                event = json.loads(await asyncio.wait_for(ws.recv(), 50))
                if event["type"] in ("response.completed", "response.failed", "error"):
                    print("terminal event:", event["type"])
                    break
    except websockets.exceptions.ConnectionClosed as error:
        print("closed:", error.code, "upstream 401:", "401" in str(error))

asyncio.run(main())
```

### Before (9071ca503e4d7e2dbda542ac3b68b15df015c762)

1. Start the unmodified checkout and send the request above
2. Observed: `closed: 1011 upstream 401: True`

### After (4ac90ba44e006af1bf8c58f410d583e38347f7c2)

1. Start the patched checkout and send the same request
2. Observed: `terminal event: response.completed`

## Type

Bug Fix

## Caveats (if any)

### Low

- Native WebSocket must already be supported by the upstream
- Existing cross-provider global fallback behavior remains outside this fix

## Final Attestation

- [x] The tests cover the reported regression and existing global fallback behavior
