### PR TITLE
fix(anthropic): preserve content-filtered finish reasons

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1367,6 +1367,8 @@ class LiteLLMAnthropicMessagesAdapter:
             return "max_tokens"
         elif openai_finish_reason == "tool_calls":
             return "tool_use"
+        elif openai_finish_reason == "content_filter":
+            return "refusal"
         return "end_turn"
 
     @staticmethod

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -57,6 +57,28 @@ def test_translate_openai_response_to_anthropic_empty_choices() -> None:
     assert result["usage"]["input_tokens"] == 10
 
 
+@pytest.mark.parametrize(("finish_reason", "stop_reason"), [("content_filter", "refusal"), ("stop", "end_turn")])
+def test_translate_chat_content_filter_without_refusal_text(finish_reason: str, stop_reason: str) -> None:
+    response: Final = ModelResponse(
+        id="chatcmpl-filtered",
+        model="openai-model",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason=finish_reason,
+                message=Message(content=None, role="assistant"),
+            )
+        ],
+        usage=Usage(prompt_tokens=12, completion_tokens=0, total_tokens=12),
+    )
+
+    result: Final = LiteLLMAnthropicMessagesAdapter().translate_openai_response_to_anthropic(response)
+
+    assert result["stop_reason"] == stop_reason
+    assert result["content"] == []
+    assert result["usage"]["input_tokens"] == 12
+
+
 def test_translate_chat_refusal_to_anthropic_response():
     response = ModelResponse(
         id="chatcmpl-refusal",

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_stop_reason.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_stop_reason.py
@@ -10,6 +10,8 @@ bridge emitted ``stop_reason: "end_turn"`` and Anthropic tool-runners
 (Claude Code, ``messages.stream``) silently dropped the tool call.
 """
 
+from typing import Final
+
 import pytest
 
 from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
@@ -18,7 +20,7 @@ from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterato
 from litellm.llms.ollama.chat.transformation import (
     OllamaChatCompletionResponseIterator,
 )
-from litellm.types.utils import ModelResponseStream
+from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices, Usage
 
 _OLLAMA_TOOL_CHUNK = {
     "model": "qwen3:8b",
@@ -77,3 +79,26 @@ def test_ollama_mid_stream_tool_call_yields_tool_use_stop_reason_sync():
 async def test_ollama_mid_stream_tool_call_yields_tool_use_stop_reason_async():
     wrapper = AnthropicStreamWrapper(completion_stream=_AsyncStream(_ollama_streamed_chunks()), model="qwen3:8b")
     _assert_tool_use_stop_reason([event async for event in wrapper])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True], ids=["sync", "async"])
+@pytest.mark.parametrize(("finish_reason", "stop_reason"), [("content_filter", "refusal"), ("stop", "end_turn")])
+async def test_content_filter_without_refusal_text(finish_reason: str, stop_reason: str, async_mode: bool) -> None:
+    chunks: Final = [
+        ModelResponseStream(choices=[StreamingChoices(delta=Delta(role="assistant", content=""), finish_reason=None)]),
+        ModelResponseStream(
+            choices=[StreamingChoices(delta=Delta(), finish_reason=finish_reason)],
+            usage=Usage(prompt_tokens=12, completion_tokens=0, total_tokens=12),
+        ),
+    ]
+    wrapper: Final = AnthropicStreamWrapper(
+        completion_stream=_AsyncStream(chunks) if async_mode else iter(chunks), model="openai-model"
+    )
+    events: Final = [event async for event in wrapper] if async_mode else list(wrapper)
+    message_deltas: Final = tuple(event for event in events if event["type"] == "message_delta")
+
+    assert len(message_deltas) == 1
+    assert message_deltas[0]["delta"]["stop_reason"] == stop_reason
+    assert message_deltas[0]["usage"]["input_tokens"] == 12
+    assert events[-1]["type"] == "message_stop"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Content-filtered responses appear successful on the Anthropic Messages endpoint

How it solves it:

- Translate `content_filter` to `refusal` for normal and streamed responses

## User Flow

Before: a developer using Anthropic Messages cannot distinguish a filtered answer from an ordinary empty completion

1. They send `POST https://litellm-domain/v1/chat/completions` with a prompt that their configured provider filters, receiving `finish_reason: content_filter`
2. They send the same prompt to `POST https://litellm-domain/v1/messages` and receive `stop_reason: end_turn`
3. They repeat the Messages request with `stream: true`; the final `message_delta` also reports `end_turn`

After: the Messages endpoint preserves the upstream refusal status

1. They send `POST https://litellm-domain/v1/chat/completions` with a prompt that their configured provider filters, receiving `finish_reason: content_filter`
2. They send the same prompt to `POST https://litellm-domain/v1/messages` and receive `stop_reason: refusal`
3. They repeat the Messages request with `stream: true`; the final `message_delta` also reports `refusal`

This describes the reported workflow and intended outcome. Local verification covers the response adapter and stream wrapper; live-provider verification remains pending

## Relevant issues

Fixes #40857

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Validation

All three content-filter regressions failed before the fix, while the three ordinary-empty-response controls passed. After the two-line mapping change, 276 tests passed across the adapter transformation, streaming stop-reason, and first-delta test files, including synchronous and asynchronous streams

Ruff 0.15.3 passes for the production tree and the adapter test directory. Formatting passes for the production file, streaming test file, and added transformation-test lines. The full transformation-test file has existing formatting differences; this draft leaves unrelated lines unchanged. Public imports pass, and the circular-import check reports no issues. The strict Ruff, type-discipline, and test-quality budget gates passed under WSL. All 80 reported GitHub CI checks pass at the current tip, and Codecov reports that all modified coverable lines are covered. Tests ran on Windows with Python 3.13, OpenAI 2.33.0, and dependencies from the frozen SDK lockfile

## Screenshots / Proof of Fix

Live-provider evidence has not been captured. This PR is a draft and is not requesting maintainer review. No provider API credentials were used, and unit-test results are not presented as end-to-end proof

### Before (f2e0a5db1eb137c0f223d38e6734f04cc5fe037f)

1. Pending capture through a real proxy with a content-filtering provider

### After (080d1a82646664bad07e8f0e61024f35b976b5a4)

1. Pending the same live-provider capture at this commit

## Type

Bug Fix

## Caveats (if any)

### Medium

- Live-provider validation remains outstanding
- The CLA assistant requires the contributor's signature before acceptance
- Greptile, Veria, and Bugbot review results remain outstanding

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

AI disclosure: OpenAI Codex wrote and tested this patch, regression tests, and description