### PR TITLE
fix(anthropic): report a content-filtered turn as a refusal on /v1/messages

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1368,16 +1368,6 @@ class LiteLLMAnthropicMessagesAdapter:
         elif openai_finish_reason == "tool_calls":
             return "tool_use"
         elif openai_finish_reason == "content_filter":
-            # A blocked turn must not arrive as `end_turn`, which is what an ordinary completed turn
-            # gets: the client cannot tell the two apart, and the block is the one thing it has to
-            # act on. `refusal` is already declared on this surface, and `_FINISH_REASON_MAP` in
-            # core_helpers already sends Anthropic `refusal` the other way to `content_filter`, so
-            # this closes the round trip rather than inventing a value (#40857).
-            #
-            # This covers the providers whose blocks carry no OpenAI `refusal` string, which the
-            # refusal-text branch below cannot see: Gemini `SAFETY`/`RECITATION`, Cohere
-            # `ERROR_TOXIC`, Bedrock `guardrail_intervened`, Azure `content_filtered` all normalize
-            # to `content_filter` and nothing else.
             return "refusal"
         return "end_turn"
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1367,6 +1367,18 @@ class LiteLLMAnthropicMessagesAdapter:
             return "max_tokens"
         elif openai_finish_reason == "tool_calls":
             return "tool_use"
+        elif openai_finish_reason == "content_filter":
+            # A blocked turn must not arrive as `end_turn`, which is what an ordinary completed turn
+            # gets: the client cannot tell the two apart, and the block is the one thing it has to
+            # act on. `refusal` is already declared on this surface, and `_FINISH_REASON_MAP` in
+            # core_helpers already sends Anthropic `refusal` the other way to `content_filter`, so
+            # this closes the round trip rather than inventing a value (#40857).
+            #
+            # This covers the providers whose blocks carry no OpenAI `refusal` string, which the
+            # refusal-text branch below cannot see: Gemini `SAFETY`/`RECITATION`, Cohere
+            # `ERROR_TOXIC`, Bedrock `guardrail_intervened`, Azure `content_filtered` all normalize
+            # to `content_filter` and nothing else.
+            return "refusal"
         return "end_turn"
 
     @staticmethod

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -82,6 +82,76 @@ def test_translate_chat_refusal_to_anthropic_response():
     }
 
 
+@pytest.mark.parametrize(
+    "openai_finish_reason,expected_stop_reason",
+    [
+        ("stop", "end_turn"),
+        ("length", "max_tokens"),
+        ("tool_calls", "tool_use"),
+        ("content_filter", "refusal"),
+        ("some_provider_specific_reason", "end_turn"),
+    ],
+)
+def test_translate_finish_reason_to_anthropic(openai_finish_reason, expected_stop_reason):
+    """`content_filter` must not fall through to `end_turn` (#40857).
+
+    A blocked turn that arrives as `end_turn` is indistinguishable from an ordinary completed one,
+    and `_FINISH_REASON_MAP` already maps Anthropic `refusal` the other way to `content_filter`, so
+    a refusal that round-trips through chat completions has to survive it.
+    """
+    adapter = LiteLLMAnthropicMessagesAdapter()
+
+    assert adapter._translate_openai_finish_reason_to_anthropic(openai_finish_reason) == expected_stop_reason
+
+
+def test_translate_content_filtered_turn_to_anthropic_response():
+    """A provider block with no OpenAI `refusal` string still reports the refusal (#40857).
+
+    This is the case the refusal-text branch cannot see: Gemini `SAFETY`, Cohere `ERROR_TOXIC`,
+    Bedrock `guardrail_intervened` and Azure `content_filtered` all normalize to `content_filter`
+    and carry no `refusal` field.
+    """
+    response = ModelResponse(
+        id="chatcmpl-content-filter",
+        model="openai-model",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="content_filter",
+                message=Message(content="partial answer", role="assistant"),
+            )
+        ],
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+    result = LiteLLMAnthropicMessagesAdapter().translate_openai_response_to_anthropic(response)
+
+    assert result["stop_reason"] == "refusal"
+    # No explanation is invented: the block carried no refusal text, and `type` is what a client
+    # branches on.
+    assert result.get("stop_details") == {"type": "refusal", "category": None, "explanation": None}
+    # The partial content the provider did emit is still delivered.
+    assert result["content"] == [{"type": "text", "text": "partial answer"}]
+
+
+def test_translate_streaming_content_filtered_turn_to_anthropic():
+    """Streaming loses it the same way: the final `message_delta` carries the stop reason (#40857)."""
+    chunk = ModelResponse(
+        id="chatcmpl-content-filter-stream",
+        model="openai-model",
+        object="chat.completion.chunk",
+        choices=[StreamingChoices(index=0, finish_reason="content_filter", delta=Delta(content=None))],
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+    result = LiteLLMAnthropicMessagesAdapter().translate_streaming_openai_response_to_anthropic(
+        response=chunk, current_content_block_index=0
+    )
+
+    assert result["type"] == "message_delta"
+    assert result["delta"]["stop_reason"] == "refusal"
+
+
 def test_translate_chat_length_takes_precedence_over_refusal():
     response = ModelResponse(
         id="chatcmpl-partial-refusal",


### PR DESCRIPTION
## TLDR

Problem this solves:

- A blocked answer looks like a normal answer on `/v1/messages`
- Same upstream reports the block fine on `/v1/chat/completions`
- Clients cannot detect or log a content-policy refusal
- Streaming loses it too

How it solves it:

- Map OpenAI `content_filter` to Anthropic `refusal`
- `refusal` is already declared on this surface
- The reverse mapping already exists, so the round trip closes
- One map, so streaming is covered too

## User Flow

Before: a developer whose app calls a safety-filtered model through the Anthropic surface cannot tell a blocked answer from a finished one, so nothing is flagged and nothing is logged

1. They send `POST https://litellm-domain/v1/messages` with `{"model": "their-model", "max_tokens": 64, "messages": [{"role": "user", "content": "<a prompt the provider blocks>"}]}`
2. The answer comes back `"stop_reason": "end_turn"` and no `stop_details`, which is exactly what a normal completed answer looks like
3. Their app treats it as a complete answer and shows the partial text to the end user with no warning
4. The same request to `POST https://litellm-domain/v1/chat/completions` does report it, as `"finish_reason": "content_filter"`, so the block reached the gateway and only this surface lost it
5. With `"stream": true`, the final `message_delta` also says `"stop_reason": "end_turn"`

After: the same request reports the refusal, so the app can branch on it

1. They send the same `POST https://litellm-domain/v1/messages`
2. The answer comes back `"stop_reason": "refusal"` with `"stop_details": {"type": "refusal", "category": null, "explanation": null}`
3. Their app sees the refusal and can retry, warn, or log it instead of presenting a blocked answer as a complete one
4. `POST https://litellm-domain/v1/chat/completions` is unchanged: still `"finish_reason": "content_filter"`
5. With `"stream": true`, the final `message_delta` now says `"stop_reason": "refusal"`

Nothing else changes: a normal answer is still `end_turn`, a truncated one still `max_tokens`, a tool call still `tool_use`, and a provider reason nobody maps still `end_turn`.

## Relevant issues

Fixes #40857

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `pytest tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py` -> 210 passed
- [x] My PR passes all required CI/CD checks (`make lint` clean locally: format check, ruff, strict-rule ceilings, basedpyright limits)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

Three tests, all in the existing adapter test file:

- the finish-reason map parametrised over `stop`, `length`, `tool_calls`, `content_filter` and an unmapped provider reason, so the fallthrough that used to swallow `content_filter` still catches anything genuinely unknown
- a content-filtered response with **no** OpenAI `refusal` string, which is the case the existing refusal-text branch cannot see
- the streaming final `message_delta`

Negative control: with the one branch removed and the tests kept, exactly those three fail, each on `assert 'end_turn' == 'refusal'`.

## Screenshots / Proof of Fix

Shared setup. Real provider blocks need a policy-violating prompt and a paid key, so the block here comes from a local OpenAI-compatible upstream that answers every request the way a guardrail does. Nothing inside LiteLLM is mocked or patched: the request goes through the running proxy, the real provider client, and the real translation.

`upstream.py` (both shapes, non-streaming and SSE):

```python
BLOCKED = {"id": "chatcmpl-blocked", "object": "chat.completion", "created": 1789200000,
           "model": "gpt-4o-mini",
           "choices": [{"index": 0, "message": {"role": "assistant", "content": "I can't help with that."},
                        "finish_reason": "content_filter"}],
           "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}}
```

`config.yaml`:

```yaml
model_list:
  - model_name: blocked-model
    litellm_params:
      model: hosted_vllm/gpt-4o-mini
      api_base: http://127.0.0.1:8791/v1
      api_key: fake-key-for-a-local-upstream
```

```bash
python upstream.py 8791 &
LITELLM_MASTER_KEY=sk-1234 litellm --config config.yaml --port 8790
```

### Before (f2e0a5db, the merge base)

#### non-streaming

1. `curl -s -X POST http://127.0.0.1:8790/v1/messages -H 'Content-Type: application/json' -H 'x-api-key: sk-1234' -H 'anthropic-version: 2023-06-01' -d '{"model":"blocked-model","max_tokens":64,"messages":[{"role":"user","content":"anything"}]}'`
2. ```
   stop_reason: end_turn | stop_details: None
   ```

#### streaming

1. the same request with `"stream": true`
2. ```
   event: message_delta
   data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"input_tokens": 11, "output_tokens": 7}}
   ```

### After (7ca89a3b)

#### non-streaming

1. the same curl
2. ```json
   {
       "id": "chatcmpl-blocked",
       "type": "message",
       "role": "assistant",
       "model": "blocked-model",
       "stop_sequence": null,
       "usage": {"input_tokens": 11, "output_tokens": 7},
       "content": [{"type": "text", "text": "I can't help with that."}],
       "stop_reason": "refusal",
       "stop_details": {"type": "refusal", "category": null, "explanation": null}
   }
   ```

#### streaming

1. the same request with `"stream": true`
2. ```
   event: message_delta
   data: {"type": "message_delta", "delta": {"stop_reason": "refusal"}, "usage": {"input_tokens": 11, "output_tokens": 7}}
   ```

#### the chat completions surface is unchanged

1. `curl -s -X POST http://127.0.0.1:8790/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"blocked-model","messages":[{"role":"user","content":"anything"}]}'`
2. ```
   finish_reason: content_filter
   ```

## One thing I found and deliberately left alone

Routing `/v1/messages` at an `openai/` model does not reach this translation at all: it goes through the Responses API path, where the Anthropic stop reason is decided separately and a `status: "incomplete"` response is reported as `max_tokens` with no `content_filter` arm. A Responses-API block would therefore be reported as "hit the token limit" rather than as a refusal. That is a different translation on a different surface, so it is not in this PR. Happy to open it as its own issue if you would like it filed.
