### PR TITLE
feat: add Wallaby (OpenAI-compatible provider) — kimi-k3

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -966,6 +966,7 @@ openai_compatible_providers: Final[list] = [
     "meta",  # Meta Model API (Muse Spark) - JSON-configured provider
     "cognition",
     "scx-ai",
+    "wallaby",  # Wallaby - JSON-configured provider
 ]
 openai_text_completion_compatible_providers: Final[list] = [  # providers that support `/v1/completions`
     "together_ai",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -130,10 +130,7 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses"
-    ]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   },
   "tensormesh": {
     "base_url": "https://serverless.tensormesh.ai/v1",
@@ -143,19 +140,13 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses"
-    ]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   },
   "parasail": {
     "base_url": "https://api.parasail.io/v1",
     "api_key_env": "PARASAIL_API_KEY",
     "api_base_env": "PARASAIL_API_BASE",
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses"
-    ],
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"],
     "special_handling": {
       "force_store_false": true
     }
@@ -175,21 +166,14 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses"
-    ]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   },
   "meta": {
     "base_url": "https://api.meta.ai/v1",
     "api_key_env": "META_API_KEY",
     "api_base_env": "META_API_BASE",
     "base_class": "openai_gpt",
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses",
-      "/v1/messages"
-    ]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/messages"]
   },
   "cognition": {
     "base_url": "https://api.cognition.ai/v1",
@@ -203,11 +187,7 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses",
-      "/v1/embeddings"
-    ]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
   },
   "scx-ai": {
     "base_url": "https://api.scx.ai/v1",
@@ -219,9 +199,7 @@
     "constraints": {
       "temperature_max": 1.99
     },
-    "supported_endpoints": [
-      "/v1/chat/completions"
-    ]
+    "supported_endpoints": ["/v1/chat/completions"]
   },
   "wallaby": {
     "base_url": "https://api.wallabytoken.com/v1",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -130,7 +130,10 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ]
   },
   "tensormesh": {
     "base_url": "https://serverless.tensormesh.ai/v1",
@@ -140,13 +143,19 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ]
   },
   "parasail": {
     "base_url": "https://api.parasail.io/v1",
     "api_key_env": "PARASAIL_API_KEY",
     "api_base_env": "PARASAIL_API_BASE",
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"],
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ],
     "special_handling": {
       "force_store_false": true
     }
@@ -166,14 +175,21 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ]
   },
   "meta": {
     "base_url": "https://api.meta.ai/v1",
     "api_key_env": "META_API_KEY",
     "api_base_env": "META_API_BASE",
     "base_class": "openai_gpt",
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/messages"]
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses",
+      "/v1/messages"
+    ]
   },
   "cognition": {
     "base_url": "https://api.cognition.ai/v1",
@@ -187,7 +203,11 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses",
+      "/v1/embeddings"
+    ]
   },
   "scx-ai": {
     "base_url": "https://api.scx.ai/v1",
@@ -199,6 +219,13 @@
     "constraints": {
       "temperature_max": 1.99
     },
-    "supported_endpoints": ["/v1/chat/completions"]
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ]
+  },
+  "wallaby": {
+    "base_url": "https://api.wallabytoken.com/v1",
+    "api_key_env": "WALLABY_API_KEY",
+    "api_base_env": "WALLABY_API_BASE"
   }
 }

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -352,6 +352,22 @@
         "supports_function_calling": true,
         "supports_pdf_input": true
     },
+    "wallaby/kimi-k3": {
+    "cache_read_input_token_cost": 2.7e-07,
+    "input_cost_per_token": 2.7e-06,
+    "litellm_provider": "wallaby",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "max_tokens": 131072,
+    "mode": "chat",
+    "output_cost_per_token": 1.35e-05,
+    "source": "https://wallabytoken.com/pricing.json",
+    "supports_function_calling": true,
+    "supports_prompt_caching": true,
+    "supports_reasoning": true,
+    "supports_response_schema": true,
+    "supports_tool_choice": true
+  },
     "amazon.nova-lite-v1:0": {
         "input_cost_per_token": 6e-08,
         "litellm_provider": "bedrock_converse",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -352,22 +352,6 @@
         "supports_function_calling": true,
         "supports_pdf_input": true
     },
-    "wallaby/kimi-k3": {
-    "cache_read_input_token_cost": 2.7e-07,
-    "input_cost_per_token": 2.7e-06,
-    "litellm_provider": "wallaby",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "max_tokens": 131072,
-    "mode": "chat",
-    "output_cost_per_token": 1.35e-05,
-    "source": "https://wallabytoken.com/pricing.json",
-    "supports_function_calling": true,
-    "supports_prompt_caching": true,
-    "supports_reasoning": true,
-    "supports_response_schema": true,
-    "supports_tool_choice": true
-  },
     "amazon.nova-lite-v1:0": {
         "input_cost_per_token": 6e-08,
         "litellm_provider": "bedrock_converse",
@@ -65079,5 +65063,21 @@
         "supports_tool_choice": false,
         "supports_response_schema": true,
         "supports_vision": false
+    },
+    "wallaby/kimi-k3": {
+        "cache_read_input_token_cost": 2.7e-07,
+        "input_cost_per_token": 2.7e-06,
+        "litellm_provider": "wallaby",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.35e-05,
+        "source": "https://wallabytoken.com/pricing.json",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     }
 }

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -2298,6 +2298,24 @@
         "rerank": true
       }
     },
+    "wallaby": {
+      "display_name": "Wallaby (`wallaby`)",
+      "url": "https://docs.litellm.ai/docs/providers/wallaby",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "interactions": false
+      }
+    },
     "wandb": {
       "display_name": "WandB Inference (`wandb`)",
       "url": "https://docs.litellm.ai/docs/providers/wandb_inference",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -65063,5 +65063,21 @@
         "supports_tool_choice": false,
         "supports_response_schema": true,
         "supports_vision": false
+    },
+    "wallaby/kimi-k3": {
+        "cache_read_input_token_cost": 2.7e-07,
+        "input_cost_per_token": 2.7e-06,
+        "litellm_provider": "wallaby",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.35e-05,
+        "source": "https://wallabytoken.com/pricing.json",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     }
 }

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2609,6 +2609,24 @@
         "rerank": true
       }
     },
+    "wallaby": {
+      "display_name": "Wallaby (`wallaby`)",
+      "url": "https://docs.litellm.ai/docs/providers/wallaby",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "interactions": false
+      }
+    },
     "wandb": {
       "display_name": "WandB Inference (`wandb`)",
       "url": "https://docs.litellm.ai/docs/providers/wandb_inference",


### PR DESCRIPTION
## What this adds

Wallaby as an OpenAI-like provider, with pricing for `wallaby/kimi-k3`.

- **Provider**: Wallaby (Wallaby Data Pty Ltd, registered in Australia) — OpenAI-compatible API for open-weight models
- **Endpoint**: `https://api.wallabytoken.com/v1`
- **Docs**: https://wallabytoken.com/docs
- **Pricing (machine-readable)**: https://wallabytoken.com/pricing.json
- **Status page**: https://status.wallabytoken.com/

## Changes

1. `litellm/llms/openai_like/providers.json` — add `wallaby` entry (base_url + `WALLABY_API_KEY` / `WALLABY_API_BASE` env vars)
2. `model_prices_and_context_window.json` — add `wallaby/kimi-k3` ($2.70 / $13.50 / $0.27 cache-read per 1M tokens; 1M context; supports reasoning, function calling, response schema, prompt caching)

## Verification

Tested locally against the live endpoint with the providers.json entry applied:

- `completion(model="wallaby/kimi-k3", ...)` non-streaming ✅
- streaming ✅ (reasoning models stream `reasoning_content` then `content`)
- explicit `temperature=0.7, top_p=0.9` from the client ✅ (the serving stack fixes sampling params; the gateway normalizes them instead of erroring)
- `response_format={"type": "json_object"}` ✅

Happy to provide a test API key for maintainer verification — just say the word.