### PR TITLE
fix(gemini): preserve candidates with finishReason and no content (#40477)

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -224,6 +224,7 @@ _FINISH_REASON_MAP: Final[dict[str, OpenAIChatCompletionFinishReason]] = {
     "IMAGE_PROHIBITED_CONTENT": "content_filter",
     "TOO_MANY_TOOL_CALLS": "stop",
     "MALFORMED_RESPONSE": "stop",
+    "NO_IMAGE": "content_filter",
     # Zhipu GLM
     "network_error": "stop",
     "sensitive": "content_filter",

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1367,6 +1367,8 @@ class LiteLLMAnthropicMessagesAdapter:
             return "max_tokens"
         elif openai_finish_reason == "tool_calls":
             return "tool_use"
+        elif openai_finish_reason in ["content_filter", "refusal"]:
+            return "refusal"
         return "end_turn"
 
     @staticmethod

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1340,6 +1340,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             "IMAGE_PROHIBITED_CONTENT",
             "TOO_MANY_TOOL_CALLS",
             "MALFORMED_RESPONSE",
+            "NO_IMAGE",
         }
     )
 
@@ -2224,21 +2225,22 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         grounding_metadata: Final[list[dict]] = []
         url_context_metadata: Final[list[dict]] = []
-        image_response: list[ImageURLListItem] | None = None
         safety_ratings: Final[list] = []
         citation_metadata: Final[list] = []
-        chat_completion_message: Final[ChatCompletionResponseMessage] = {"role": "assistant"}
-        chat_completion_logprobs: ChoiceLogprobs | None = None
-        tools: list[ChatCompletionToolCallChunk] | None = []
-        functions: ChatCompletionToolCallFunctionChunk | None = None
-        thinking_blocks: list[ChatCompletionThinkingBlock] | None = None
-        reasoning_content: str | None = None
-        thought_signatures: Sequence[str] | None = None
-        server_side_tool_invocations: list[dict[str, object]] | None = None
 
         for idx, candidate in enumerate(_candidates):
-            if "content" not in candidate:
+            if "content" not in candidate and "finishReason" not in candidate:
                 continue
+
+            image_response: list[ImageURLListItem] | None = None
+            chat_completion_message: ChatCompletionResponseMessage = {"role": "assistant"}
+            chat_completion_logprobs: ChoiceLogprobs | None = None
+            tools: list[ChatCompletionToolCallChunk] | None = []
+            functions: ChatCompletionToolCallFunctionChunk | None = None
+            thinking_blocks: list[ChatCompletionThinkingBlock] | None = None
+            reasoning_content: str | None = None
+            thought_signatures: Sequence[str] | None = None
+            server_side_tool_invocations: list[dict[str, object]] | None = None
 
             # Extract metadata using helper function
             (
@@ -2253,7 +2255,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             safety_ratings.extend(candidate_safety_ratings)
             citation_metadata.extend(candidate_citation_metadata)
 
-            if "parts" in candidate["content"]:
+            if "content" in candidate and candidate["content"] and "parts" in candidate["content"]:
                 (
                     content,
                     reasoning_content,
@@ -2348,6 +2350,11 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 tool_invocation_fields["server_side_tool_invocations"] = server_side_tool_invocations
                 chat_completion_message["provider_specific_fields"] = tool_invocation_fields
 
+            if candidate.get("finishReason"):
+                finish_reason_fields = chat_completion_message.get("provider_specific_fields") or {}
+                finish_reason_fields["native_finish_reason"] = candidate.get("finishReason")
+                chat_completion_message["provider_specific_fields"] = finish_reason_fields
+
             if isinstance(model_response, ModelResponseStream):
                 choice = VertexGeminiConfig._create_streaming_choice(
                     chat_completion_message=chat_completion_message,
@@ -2368,6 +2375,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                     message=chat_completion_message,
                     logprobs=chat_completion_logprobs,
                     enhancements=None,
+                    provider_specific_fields=chat_completion_message.get("provider_specific_fields"),
                 )
                 model_response.choices.append(choice)
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2272,13 +2272,27 @@ class LiteLLMCompletionResponsesConfig:
         if choices and len(choices) > 0:
             finish_reason = choices[0].finish_reason
 
+        status: Final[ResponsesAPIStatus] = (
+            LiteLLMCompletionResponsesConfig._map_chat_completion_finish_reason_to_responses_status(
+                finish_reason
+            )
+        )
+        incomplete_details = getattr(chat_completion_response, "incomplete_details", None)
+        if incomplete_details is None and status == "incomplete":
+            from openai.types.responses.response import IncompleteDetails
+
+            if finish_reason == "length":
+                incomplete_details = IncompleteDetails(reason="max_output_tokens")
+            elif finish_reason in ["content_filter", "refusal"]:
+                incomplete_details = IncompleteDetails(reason="content_filter")
+
         responses_api_response: Final[ResponsesAPIResponse] = ResponsesAPIResponse(
             id=chat_completion_response.id,
             created_at=chat_completion_response.created,
             model=chat_completion_response.model,
             object="response",
             error=getattr(chat_completion_response, "error", None),
-            incomplete_details=getattr(chat_completion_response, "incomplete_details", None),
+            incomplete_details=incomplete_details,
             instructions=getattr(chat_completion_response, "instructions", None),
             metadata=getattr(chat_completion_response, "metadata", {}),
             output=LiteLLMCompletionResponsesConfig._transform_chat_completion_choices_to_responses_output(
@@ -2296,9 +2310,7 @@ class LiteLLMCompletionResponsesConfig:
             max_output_tokens=getattr(chat_completion_response, "max_output_tokens", None),
             previous_response_id=getattr(chat_completion_response, "previous_response_id", None),
             reasoning=None,
-            status=LiteLLMCompletionResponsesConfig._map_chat_completion_finish_reason_to_responses_status(
-                finish_reason
-            ),
+            status=status,
             text={},
             truncation=getattr(chat_completion_response, "truncation", None),
             usage=LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2273,9 +2273,7 @@ class LiteLLMCompletionResponsesConfig:
             finish_reason = choices[0].finish_reason
 
         status: Final[ResponsesAPIStatus] = (
-            LiteLLMCompletionResponsesConfig._map_chat_completion_finish_reason_to_responses_status(
-                finish_reason
-            )
+            LiteLLMCompletionResponsesConfig._map_chat_completion_finish_reason_to_responses_status(finish_reason)
         )
         incomplete_details = getattr(chat_completion_response, "incomplete_details", None)
         if incomplete_details is None and status == "incomplete":

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -102,6 +102,46 @@ def test_translate_chat_length_takes_precedence_over_refusal():
     assert result.get("stop_details") is None
 
 
+def test_translate_chat_content_filter_to_anthropic_response():
+    response = ModelResponse(
+        id="chatcmpl-content-filter",
+        model="openai-model",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="content_filter",
+                message=Message(content=None, role="assistant"),
+            )
+        ],
+        usage=Usage(prompt_tokens=1, completion_tokens=0, total_tokens=1),
+    )
+
+    result = LiteLLMAnthropicMessagesAdapter().translate_openai_response_to_anthropic(response)
+
+    assert result["content"] == []
+    assert result["stop_reason"] == "refusal"
+
+
+def test_translate_chat_refusal_finish_reason_to_anthropic_response():
+    response = ModelResponse(
+        id="chatcmpl-refusal-reason",
+        model="openai-model",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="refusal",
+                message=Message(content=None, role="assistant"),
+            )
+        ],
+        usage=Usage(prompt_tokens=1, completion_tokens=0, total_tokens=1),
+    )
+
+    result = LiteLLMAnthropicMessagesAdapter().translate_openai_response_to_anthropic(response)
+
+    assert result["content"] == []
+    assert result["stop_reason"] == "refusal"
+
+
 def test_translate_streaming_openai_chunk_to_anthropic_content_block():
     choices = [
         StreamingChoices(

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5836,3 +5836,149 @@ def test_supported_reasoning_efforts_still_map(model):
             drop_params=False,
         )
         assert "thinkingConfig" in result
+
+
+def test_gemini_candidate_with_finish_reason_no_content_chat_completion():
+    config = VertexGeminiConfig()
+    completion_response = {
+        "candidates": [
+            {
+                "finishReason": "NO_IMAGE",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 19,
+            "candidatesTokenCount": 0,
+            "totalTokenCount": 19,
+        },
+    }
+    model_response = ModelResponse()
+    logging_obj = MagicMock()
+    raw_response = MagicMock()
+    raw_response.headers = {}
+
+    resp = config._transform_google_generate_content_to_openai_model_response(
+        completion_response=completion_response,
+        model_response=model_response,
+        model="gemini-2.5-flash-image",
+        logging_obj=logging_obj,
+        raw_response=raw_response,
+    )
+    assert len(resp.choices) == 1
+    assert resp.choices[0].finish_reason == "content_filter"
+    assert resp.choices[0].message.content is None
+    assert resp.choices[0].provider_specific_fields["native_finish_reason"] == "NO_IMAGE"
+
+
+def test_gemini_candidate_with_finish_reason_no_content_anthropic_messages():
+    from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+        LiteLLMAnthropicMessagesAdapter,
+    )
+
+    config = VertexGeminiConfig()
+    completion_response = {
+        "candidates": [
+            {
+                "finishReason": "NO_IMAGE",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 19,
+            "candidatesTokenCount": 0,
+            "totalTokenCount": 19,
+        },
+    }
+    resp = config._transform_google_generate_content_to_openai_model_response(
+        completion_response=completion_response,
+        model_response=ModelResponse(),
+        model="gemini-2.5-flash-image",
+        logging_obj=MagicMock(),
+        raw_response=MagicMock(headers={}),
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    anthropic_resp = adapter.translate_openai_response_to_anthropic(
+        response=resp,
+        tool_name_mapping={},
+    )
+    assert anthropic_resp["stop_reason"] == "refusal"
+    assert anthropic_resp["content"] == []
+
+
+def test_gemini_candidate_with_finish_reason_no_content_responses_api():
+    from litellm.responses.litellm_completion_transformation.transformation import (
+        LiteLLMCompletionResponsesConfig,
+    )
+
+    config = VertexGeminiConfig()
+    completion_response = {
+        "candidates": [
+            {
+                "finishReason": "NO_IMAGE",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 19,
+            "candidatesTokenCount": 0,
+            "totalTokenCount": 19,
+        },
+    }
+    resp = config._transform_google_generate_content_to_openai_model_response(
+        completion_response=completion_response,
+        model_response=ModelResponse(),
+        model="gemini-2.5-flash-image",
+        logging_obj=MagicMock(),
+        raw_response=MagicMock(headers={}),
+    )
+
+    responses_resp = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+        request_input="Generate picture",
+        responses_api_request={},
+        chat_completion_response=resp,
+    )
+    assert responses_resp.status == "incomplete"
+    assert responses_resp.incomplete_details is not None
+    assert responses_resp.incomplete_details.reason == "content_filter"
+
+
+def test_gemini_candidate_other_finish_reasons_no_content():
+    from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+        LiteLLMAnthropicMessagesAdapter,
+    )
+    from litellm.responses.litellm_completion_transformation.transformation import (
+        LiteLLMCompletionResponsesConfig,
+    )
+
+    config = VertexGeminiConfig()
+    max_tokens_response = {
+        "candidates": [{"finishReason": "MAX_TOKENS", "index": 0}],
+        "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 50, "totalTokenCount": 60},
+    }
+    resp_length = config._transform_google_generate_content_to_openai_model_response(
+        completion_response=max_tokens_response,
+        model_response=ModelResponse(),
+        model="gemini-2.5-flash",
+        logging_obj=MagicMock(),
+        raw_response=MagicMock(headers={}),
+    )
+    assert len(resp_length.choices) == 1
+    assert resp_length.choices[0].finish_reason == "length"
+    assert resp_length.choices[0].provider_specific_fields["native_finish_reason"] == "MAX_TOKENS"
+
+    anthropic_length = LiteLLMAnthropicMessagesAdapter().translate_openai_response_to_anthropic(
+        response=resp_length,
+        tool_name_mapping={},
+    )
+    assert anthropic_length["stop_reason"] == "max_tokens"
+
+    responses_length = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+        request_input="thinking request",
+        responses_api_request={},
+        chat_completion_response=resp_length,
+    )
+    assert responses_length.status == "incomplete"
+    assert responses_length.incomplete_details.reason == "max_output_tokens"
+

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -4246,3 +4246,65 @@ class TestStreamingSnapshotItemIds:
         reasoning_items = _bridged_output_items(completed_event.response, "reasoning")
         assert len(reasoning_items) == 1
         assert reasoning_items[0].id == streamed_event.item_id
+
+
+def test_transform_chat_completion_response_incomplete_details():
+    from openai.types.responses.response import IncompleteDetails
+
+    resp_length = ModelResponse(
+        id="resp-length",
+        choices=[Choices(index=0, finish_reason="length", message=Message(content="cutoff", role="assistant"))],
+        model="gpt-4o",
+    )
+    result_length = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+        request_input="test prompt",
+        responses_api_request={},
+        chat_completion_response=resp_length,
+    )
+    assert result_length.status == "incomplete"
+    assert result_length.incomplete_details is not None
+    assert result_length.incomplete_details.reason == "max_output_tokens"
+
+    resp_filter = ModelResponse(
+        id="resp-filter",
+        choices=[Choices(index=0, finish_reason="content_filter", message=Message(content=None, role="assistant"))],
+        model="gpt-4o",
+    )
+    result_filter = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+        request_input="test prompt",
+        responses_api_request={},
+        chat_completion_response=resp_filter,
+    )
+    assert result_filter.status == "incomplete"
+    assert result_filter.incomplete_details is not None
+    assert result_filter.incomplete_details.reason == "content_filter"
+
+    resp_refusal = ModelResponse(
+        id="resp-refusal",
+        choices=[Choices(index=0, finish_reason="refusal", message=Message(content=None, role="assistant"))],
+        model="gpt-4o",
+    )
+    result_refusal = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+        request_input="test prompt",
+        responses_api_request={},
+        chat_completion_response=resp_refusal,
+    )
+    assert result_refusal.status == "incomplete"
+    assert result_refusal.incomplete_details is not None
+    assert result_refusal.incomplete_details.reason == "content_filter"
+
+    existing_details = IncompleteDetails(reason="content_filter")
+    resp_existing = ModelResponse(
+        id="resp-existing",
+        choices=[Choices(index=0, finish_reason="length", message=Message(content="cutoff", role="assistant"))],
+        model="gpt-4o",
+    )
+    resp_existing.incomplete_details = existing_details
+    result_existing = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+        request_input="test prompt",
+        responses_api_request={},
+        chat_completion_response=resp_existing,
+    )
+    assert result_existing.status == "incomplete"
+    assert result_existing.incomplete_details == existing_details
+


### PR DESCRIPTION
## TLDR

Problem this solves:

- A Gemini candidate with a `finishReason` but no `content` was dropped, so the chat completion came back `choices: []`
- `/v1/messages` then reported `end_turn` and `/v1/responses` reported `completed` for a request the model declined
- Six documented Gemini finish reasons (`NO_IMAGE` included) had no mapping at all
- A multi-candidate response leaked tool calls and reasoning from one candidate into the next

How it solves it:

- Keeps the candidate as a choice with an empty assistant message and the mapped `finish_reason`
- Maps `NO_IMAGE`, `IMAGE_RECITATION`, `IMAGE_OTHER`, `ESCALATION` to `content_filter` and `UNEXPECTED_TOOL_CALL`, `MISSING_THOUGHT_SIGNATURE` to `stop`
- Keeps the raw Gemini value as `provider_specific_fields.native_finish_reason` on every non-stream choice
- `/v1/messages` turns `content_filter` into `stop_reason: refusal`
- `/v1/responses` turns it into `status: incomplete` with `incomplete_details.reason`
- Resets per-candidate state on every loop pass

Mapping decisions, with the alternatives considered:

| Gemini `finishReason` | `finish_reason` | `/v1/messages` | `/v1/responses` | Alternative rejected |
| --- | --- | --- | --- | --- |
| `NO_IMAGE` | `content_filter` | `refusal` | `incomplete`, `content_filter` | `stop` hides the decline, `length` is false |
| `IMAGE_RECITATION`, `IMAGE_OTHER`, `ESCALATION` | `content_filter` | `refusal` | `incomplete`, `content_filter` | mirrors `RECITATION`, `OTHER`, `BLOCKLIST` |
| `UNEXPECTED_TOOL_CALL`, `MISSING_THOUGHT_SIGNATURE` | `stop` | `end_turn` | `completed` | mirrors `MALFORMED_FUNCTION_CALL`; `content_filter` would read as a policy block |
| `MAX_TOKENS` with no content | `length` | `max_tokens` | `incomplete`, `max_output_tokens` | already mapped, only the drop changed |

The raw value rides on the choice's `provider_specific_fields` because that is where `Choices` already puts a raw provider finish reason; a message-level copy (this PR's first revision) or a delta-level copy in streams would change response shapes clients already parse. The empty message keeps `content: null` rather than `""` so a client that checks for text still sees none

Builds on #40252 (@JoaVirtudes19), #38301 (@codechrl), and #36870 (@yukimaru77), which fixed the same skip for the `MAX_TOKENS` shape, and overlaps #40867 (@Anurag-M1), which took the same endpoint mapping approach for `NO_IMAGE`

## User Flow

Before: a developer whose app asks `gemini-2.5-flash-image` a text-only question gets an empty reply with no reason when the model declines to draw, so the app cannot tell a refusal from a blank answer

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "gemini-2.5-flash-image"` and the question `What is 2+2? Reply in text only. Do not generate any image.`
2. HTTP 200 comes back with `"choices": []` and `completion_tokens: 0`; there is no `finish_reason` anywhere in the body
3. With `"stream": true` the only chunk carries an empty delta and `"finish_reason": "stop"`, as if the model had finished normally
4. Their Anthropic-SDK app sends the same question to POST https://litellm-domain/v1/messages and gets HTTP 200 with `"content": []` and `"stop_reason": "end_turn"`, which reads as a normal empty turn
5. With `"stream": true` the stream ends with a `message_delta` carrying `"stop_reason": "end_turn"`
6. Their Responses-API app sends it to POST https://litellm-domain/v1/responses and gets HTTP 200 with `"status": "completed"`, `"incomplete_details": null`, and `"output": []`

After: the same requests carry the model's reason, so the app can say the model declined to generate an image instead of showing a blank

1. They send the same POST https://litellm-domain/v1/chat/completions
2. HTTP 200 comes back with one choice: an assistant message with no content, `"finish_reason": "content_filter"`, and `"provider_specific_fields": {"native_finish_reason": "NO_IMAGE"}`
3. With `"stream": true` the only chunk carries an empty delta and `"finish_reason": "content_filter"`
4. POST https://litellm-domain/v1/messages returns HTTP 200 with `"content": []` and `"stop_reason": "refusal"`
5. With `"stream": true` the final `message_delta` carries `"stop_reason": "refusal"`
6. POST https://litellm-domain/v1/responses returns HTTP 200 with `"status": "incomplete"` and `"incomplete_details": {"reason": "content_filter"}`

## Relevant issues

Fixes #40477
Fixes #36881

## Affected release

## Linear ticket

Resolves LIT-7413

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs hit the real Gemini API through a proxy booted with `--num_workers 2` from the named commit, the Before one at the merge base and the After one at the PR tip, same config, same commands

`config.yaml`:

```yaml
model_list:
  - model_name: gemini-2.5-flash-image
    litellm_params:
      model: gemini/gemini-2.5-flash-image
      api_key: os.environ/GEMINI_API_KEY
      modalities: ["image"]
  - model_name: gemini-2.5-flash
    litellm_params:
      model: gemini/gemini-2.5-flash
      api_key: os.environ/GEMINI_API_KEY

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

```sh
python litellm/proxy/proxy_cli.py --config config.yaml --port $PORT --num_workers 2
H=(-H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json")
```

### Before (c553bc92bd)

#### /v1/chat/completions

1. Run

   ```sh
   curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:20538/v1/chat/completions "${H[@]}" -d '{"model": "gemini-2.5-flash-image", "messages": [{"role": "user", "content": "What is 2+2? Reply in text only. Do not generate any image."}]}' | jq -Rrc 'fromjson? // . | if type=="object" then {choices, usage: {completion_tokens: .usage.completion_tokens}} else . end'
   ```

2. Observed

   ```
   {"choices":[],"usage":{"completion_tokens":0}}
   HTTP 200
   ```

#### /v1/chat/completions with "stream": true

1. Run

   ```sh
   curl -sN http://127.0.0.1:20538/v1/chat/completions "${H[@]}" -d '{"model": "gemini-2.5-flash-image", "stream": true, "messages": [{"role": "user", "content": "What is 2+2? Reply in text only. Do not generate any image."}]}' | grep '^data:' | sed 's/^data: //' | jq -Rrc 'fromjson? // . | if type=="object" then {choices} else . end'
   ```

2. Observed

   ```
   {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
   [DONE]
   ```

#### /v1/messages

1. Run

   ```sh
   curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:20538/v1/messages "${H[@]}" -d '{"model": "gemini-2.5-flash-image", "max_tokens": 256, "messages": [{"role": "user", "content": "What is 2+2? Reply in text only. Do not generate any image."}]}' | jq -Rrc 'fromjson? // . | if type=="object" then {content, stop_reason} else . end'
   ```

2. Observed

   ```
   {"content":[],"stop_reason":"end_turn"}
   HTTP 200
   ```

#### /v1/messages with "stream": true

1. Run

   ```sh
   curl -sN http://127.0.0.1:20538/v1/messages "${H[@]}" -d '{"model": "gemini-2.5-flash-image", "max_tokens": 256, "stream": true, "messages": [{"role": "user", "content": "What is 2+2? Reply in text only. Do not generate any image."}]}' | grep '^data:'
   ```

2. Observed

   ```
   data: {"type": "message_start", "message": {"id": "msg_2d117753-9237-434d-8480-1c977991ed9c", "type": "message", "role": "assistant", "content": [], "model": "gemini-2.5-flash-image", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
   data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
   data: {"type": "content_block_stop", "index": 0}
   data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"input_tokens": 19, "output_tokens": 0}}
   data: {"type": "message_stop"}
   ```

#### /v1/responses

1. Run

   ```sh
   curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:20538/v1/responses "${H[@]}" -d '{"model": "gemini-2.5-flash-image", "input": "What is 2+2? Reply in text only. Do not generate any image."}' | jq -Rrc 'fromjson? // . | if type=="object" then {status, incomplete_details, output} else . end'
   ```

2. Observed

   ```
   {"status":"completed","incomplete_details":null,"output":[]}
   HTTP 200
   ```

#### /v1/chat/completions, a model that answers (unchanged path)

1. Run

   ```sh
   curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:20538/v1/chat/completions "${H[@]}" -d '{"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Reply with the single word: pong"}]}' | jq -Rrc 'fromjson? // . | if type=="object" then {choices} else . end'
   ```

2. Observed

   ```
   {"choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant","images":[],"thinking_blocks":[]}}]}
   HTTP 200
   ```

### After (cf05466a27)

#### /v1/chat/completions

1. Run

   ```sh
   curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:31900/v1/chat/completions "${H[@]}" -d '{"model": "gemini-2.5-flash-image", "messages": [{"role": "user", "content": "What is 2+2? Reply in text only. Do not generate any image."}]}' | jq -Rrc 'fromjson? // . | if type=="object" then {choices, usage: {completion_tokens: .usage.completion_tokens}} else . end'
   ```

2. Observed

   ```
   {"choices":[{"finish_reason":"content_filter","index":0,"message":{"role":"assistant","content":null},"provider_specific_fields":{"native_finish_reason":"NO_IMAGE"}}],"usage":{"completion_tokens":0}}
   HTTP 200
   ```

#### /v1/chat/completions with "stream": true

1. Run

   ```sh
   curl -sN http://127.0.0.1:31900/v1/chat/completions "${H[@]}" -d '{"model": "gemini-2.5-flash-image", "stream": true, "messages": [{"role": "user", "content": "What is 2+2? Reply in text only. Do not generate any image."}]}' | grep '^data:' | sed 's/^data: //' | jq -Rrc 'fromjson? // . | if type=="object" then {choices} else . end'
   ```

2. Observed

   ```
   {"choices":[{"index":0,"delta":{},"finish_reason":"content_filter"}]}
   [DONE]
   ```

#### /v1/messages

1. Run

   ```sh
   curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:31900/v1/messages "${H[@]}" -d '{"model": "gemini-2.5-flash-image", "max_tokens": 256, "messages": [{"role": "user", "content": "What is 2+2? Reply in text only. Do not generate any image."}]}' | jq -Rrc 'fromjson? // . | if type=="object" then {content, stop_reason} else . end'
   ```

2. Observed

   ```
   {"content":[],"stop_reason":"refusal"}
   HTTP 200
   ```

#### /v1/messages with "stream": true

1. Run

   ```sh
   curl -sN http://127.0.0.1:31900/v1/messages "${H[@]}" -d '{"model": "gemini-2.5-flash-image", "max_tokens": 256, "stream": true, "messages": [{"role": "user", "content": "What is 2+2? Reply in text only. Do not generate any image."}]}' | grep '^data:'
   ```

2. Observed

   ```
   data: {"type": "message_start", "message": {"id": "msg_589b92b0-1816-476a-b109-4bdea4b0f87e", "type": "message", "role": "assistant", "content": [], "model": "gemini-2.5-flash-image", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
   data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
   data: {"type": "content_block_stop", "index": 0}
   data: {"type": "message_delta", "delta": {"stop_reason": "refusal"}, "usage": {"input_tokens": 19, "output_tokens": 0}}
   data: {"type": "message_stop"}
   ```

#### /v1/responses

1. Run

   ```sh
   curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:31900/v1/responses "${H[@]}" -d '{"model": "gemini-2.5-flash-image", "input": "What is 2+2? Reply in text only. Do not generate any image."}' | jq -Rrc 'fromjson? // . | if type=="object" then {status, incomplete_details, output} else . end'
   ```

2. Observed

   ```
   {"status":"incomplete","incomplete_details":{"reason":"content_filter"},"output":[]}
   HTTP 200
   ```

#### /v1/chat/completions, a model that answers (unchanged path)

1. Run

   ```sh
   curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:31900/v1/chat/completions "${H[@]}" -d '{"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Reply with the single word: pong"}]}' | jq -Rrc 'fromjson? // . | if type=="object" then {choices} else . end'
   ```

2. Observed

   ```
   {"choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant","images":[],"thinking_blocks":[]},"provider_specific_fields":{"native_finish_reason":"STOP"}}]}
   HTTP 200
   ```

Observations from the run:

- Every Gemini choice now carries `native_finish_reason`, `STOP` included (this PR)
- Streaming chat chunks carry no `provider_specific_fields` (left alone)
- `MAX_TOKENS` with no content did not reproduce live today

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- `/v1/messages` now returns `refusal` for every provider's `content_filter`, where it used to return `end_turn`
  - `refusal` is a documented Anthropic stop reason; clients keyed on `end_turn` for filtered replies see the new value
- The `MAX_TOKENS` with no content shape from #36881 did not reproduce live today: `gemini-2.5-flash` returns a thought summary part, so `length` was already surfaced; the fix for that shape is covered by unit tests only
- Every non-stream Gemini choice now carries `provider_specific_fields.native_finish_reason`, a normal `STOP` included; the field is additive and OpenAI-compatible clients ignore it
- In a stream the raw Gemini value is not copied onto the delta; only non-stream choices carry `native_finish_reason`
- The empty assistant message keeps `content: null`, not an empty string

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
