### PR TITLE
fix(key): recover from a cascade-deleted key instead of failing the apply

### DIFF
--- a/terraform/provider/CHANGELOG.md
+++ b/terraform/provider/CHANGELOG.md
@@ -37,6 +37,7 @@ longer signal it.
 
 ### Fixed
 
+- **key**: An update that changes `team_id` and fails because the key was already cascade-deleted along with its previous team now recovers by recreating the key under the new team, instead of aborting the apply. The key's absence is confirmed against the proxy first, so an unrelated failure still errors out, and a `team_id` change between two teams that both still exist stays a plain in-place update
 - **team**: Read now decodes the `team_info` envelope `/team/info` actually returns, so team attributes refresh from the proxy instead of always falling back to the prior state
 - **key**: Read now unwraps the `info` envelope `/key/info` actually returns; previously reads mapped nothing back into state, so drift on a key was never detected
 - **key**: Read now picks up `model_rpm_limit`, `model_tpm_limit`, `guardrails`, `tags`, `enforced_params`, `allowed_passthrough_routes`, `rpm_limit_type`, `tpm_limit_type` and `prompts` from `info.metadata`, where the proxy actually stores them; previously they stayed empty in state, so a matching config showed a permanent phantom diff on them and out-of-band changes to them were never detected

--- a/terraform/provider/litellm/resource_key.go
+++ b/terraform/provider/litellm/resource_key.go
@@ -3,6 +3,7 @@ package litellm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 
@@ -321,17 +322,40 @@ func resourceKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 
 	metadata, err := plannedKeyMetadata(c, d)
 	if err != nil {
-		d.Partial(true)
-		return diag.FromErr(fmt.Errorf("error updating key: %s", err))
+		return failedKeyUpdate(ctx, d, m, err)
 	}
 	key.Metadata = metadata
 
 	if _, err := c.UpdateKey(key); err != nil {
-		d.Partial(true)
-		return diag.FromErr(fmt.Errorf("error updating key: %s", err))
+		return failedKeyUpdate(ctx, d, m, err)
 	}
 
 	return resourceKeyRead(ctx, d, m)
+}
+
+// Deleting a team cascade-deletes its keys, so an apply that moves a key onto a
+// replacement team can find the key already gone, and recreating it is the only
+// way forward. Confirming it is really gone keeps an unrelated 404 (a rejected
+// project_id, say) a hard failure rather than silently orphaning a live key.
+func failedKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}, err error) diag.Diagnostics {
+	c := m.(*Client)
+	if d.HasChange("team_id") && keyIsGone(c, d.Id(), err) {
+		log.Printf("[WARN] Key %q no longer exists, most likely cascade-deleted with its previous team; recreating it under the new team_id", d.Id())
+		return resourceKeyCreate(ctx, d, m)
+	}
+	d.Partial(true)
+	return diag.FromErr(fmt.Errorf("error updating key: %s", err))
+}
+
+func keyIsGone(c *Client, keyID string, err error) bool {
+	if errors.Is(err, errKeyGone) {
+		return true
+	}
+	if !isNotFound(err) {
+		return false
+	}
+	key, getErr := c.GetKey(keyID)
+	return getErr == nil && key == nil
 }
 
 func changedMap(d *schema.ResourceData, name string) map[string]interface{} {
@@ -340,6 +364,8 @@ func changedMap(d *schema.ResourceData, name string) map[string]interface{} {
 	}
 	return d.Get(name).(map[string]interface{})
 }
+
+var errKeyGone = errors.New("no longer exists")
 
 func plannedKeyMetadata(c *Client, d *schema.ResourceData) (map[string]interface{}, error) {
 	if !d.HasChange("metadata") {
@@ -350,7 +376,7 @@ func plannedKeyMetadata(c *Client, d *schema.ResourceData) (map[string]interface
 		return nil, err
 	}
 	if current == nil {
-		return nil, fmt.Errorf("key %s no longer exists", d.Id())
+		return nil, fmt.Errorf("key %s %w", d.Id(), errKeyGone)
 	}
 	oldDeclared, newDeclared := d.GetChange("metadata")
 	return mergeKeyMetadata(current.Metadata, oldDeclared.(map[string]interface{}), newDeclared.(map[string]interface{})), nil

--- a/terraform/provider/litellm/resource_key_test.go
+++ b/terraform/provider/litellm/resource_key_test.go
@@ -7,8 +7,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -684,5 +686,193 @@ func TestKeyUpdateOmitsUnchangedDuration(t *testing.T) {
 	}
 	if v, present := proxy.updates[0]["duration"]; present {
 		t.Errorf("update payload unexpectedly contains duration = %v", v)
+	}
+}
+
+// newKeyUpdateResourceData builds a *schema.ResourceData reflecting a real
+// state -> config diff for team_id (unlike schema.TestResourceDataRaw, which
+// has no notion of prior state), so d.HasChange("team_id") behaves the way it
+// does during a real Update call.
+func newKeyUpdateResourceData(t *testing.T, id, oldTeamID, newTeamID string) *schema.ResourceData {
+	t.Helper()
+	state := &terraform.InstanceState{ID: id, Attributes: map[string]string{"team_id": oldTeamID}}
+	diff := &terraform.InstanceDiff{Attributes: map[string]*terraform.ResourceAttrDiff{
+		"team_id": {Old: oldTeamID, New: newTeamID},
+	}}
+	d, err := schema.InternalMap(resourceKey().Schema).Data(state, diff)
+	if err != nil {
+		t.Fatalf("building ResourceData returned error: %v", err)
+	}
+	return d
+}
+
+// keyRecoveryProxy fakes the two responses the cascade-delete recovery path
+// turns on: what POST /key/update returns, and whether GET /key/info still
+// finds the key afterwards.
+type keyRecoveryProxy struct {
+	updateStatus  int
+	updateBody    string
+	staleKeyGone  bool
+	updateCalls   int32
+	generateCalls int32
+}
+
+const keyNotFoundBody = `{"error":{"message":"Key not found.","type":"not_found_error","param":"key","code":"404"}}`
+
+func (p *keyRecoveryProxy) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/key/update":
+			atomic.AddInt32(&p.updateCalls, 1)
+			w.WriteHeader(p.updateStatus)
+			io.WriteString(w, p.updateBody)
+		case "/key/generate":
+			atomic.AddInt32(&p.generateCalls, 1)
+			io.WriteString(w, `{"key": "sk-new", "token_id": "new-token"}`)
+		case "/key/info":
+			requested := r.URL.Query().Get("key")
+			if p.staleKeyGone && requested != "new-token" {
+				w.WriteHeader(http.StatusNotFound)
+				io.WriteString(w, keyNotFoundBody)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"key":  requested,
+				"info": map[string]interface{}{"team_id": "team-b"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func runKeyUpdate(t *testing.T, p *keyRecoveryProxy, d *schema.ResourceData) diag.Diagnostics {
+	t.Helper()
+	srv := httptest.NewServer(p.handler())
+	defer srv.Close()
+	return resourceKeyUpdate(context.Background(), d, NewClient(srv.URL, "test-key", true))
+}
+
+// Reassigning a key between two teams that both still exist is a plain
+// in-place /key/update and must not be turned into a destroy/recreate.
+func TestResourceKeyUpdateTeamReassignmentStaysInPlace(t *testing.T) {
+	proxy := &keyRecoveryProxy{updateStatus: http.StatusOK, updateBody: `{"key": "hash-1"}`}
+	d := newKeyUpdateResourceData(t, "hash-1", "team-a", "team-b")
+
+	if diags := runKeyUpdate(t, proxy, d); diags.HasError() {
+		t.Fatalf("update returned error: %v", diags)
+	}
+	if got := atomic.LoadInt32(&proxy.generateCalls); got != 0 {
+		t.Errorf("a benign team reassignment must not recreate the key, got %d /key/generate calls", got)
+	}
+	if d.Id() != "hash-1" {
+		t.Errorf("Id = %q, want hash-1 unchanged", d.Id())
+	}
+}
+
+// The reported bug: the key was cascade-deleted along with its old team, so
+// /key/update 404s and the apply must recover by recreating it.
+func TestResourceKeyUpdateRecreatesCascadeDeletedKey(t *testing.T) {
+	proxy := &keyRecoveryProxy{updateStatus: http.StatusNotFound, updateBody: keyNotFoundBody, staleKeyGone: true}
+	d := newKeyUpdateResourceData(t, "stale-token", "team-a", "team-b")
+
+	if diags := runKeyUpdate(t, proxy, d); diags.HasError() {
+		t.Fatalf("a cascade-deleted key must be recreated, not error: %v", diags)
+	}
+	if got := atomic.LoadInt32(&proxy.updateCalls); got != 1 {
+		t.Errorf("expected 1 /key/update attempt before recovering, got %d", got)
+	}
+	if got := atomic.LoadInt32(&proxy.generateCalls); got != 1 {
+		t.Errorf("expected exactly 1 /key/generate recreate, got %d", got)
+	}
+	if d.Id() != "new-token" {
+		t.Errorf("Id = %q, want the recreated key's new-token", d.Id())
+	}
+}
+
+// /key/update 404s for reasons other than a missing key, a rejected
+// project_id among them. Recovering on the status code alone would orphan a
+// key that is still live on the proxy, so the key's absence must be confirmed.
+func TestResourceKeyUpdateNotFoundWithLiveKeyFailsLoudly(t *testing.T) {
+	proxy := &keyRecoveryProxy{
+		updateStatus: http.StatusNotFound,
+		updateBody:   `{"error":{"message":"Project not found, project_id=proj-1"}}`,
+	}
+	d := newKeyUpdateResourceData(t, "hash-1", "team-a", "team-b")
+
+	if diags := runKeyUpdate(t, proxy, d); !diags.HasError() {
+		t.Fatal("a 404 on a key that still exists must stay an error")
+	}
+	if got := atomic.LoadInt32(&proxy.generateCalls); got != 0 {
+		t.Errorf("expected no recreate while the key is still live, got %d /key/generate calls", got)
+	}
+	if d.Id() != "hash-1" {
+		t.Errorf("Id = %q, want hash-1 untouched on a hard failure", d.Id())
+	}
+}
+
+// A key gone for some reason unrelated to a team move still fails loudly.
+func TestResourceKeyUpdateNotFoundWithoutTeamChangeFailsLoudly(t *testing.T) {
+	proxy := &keyRecoveryProxy{updateStatus: http.StatusNotFound, updateBody: keyNotFoundBody, staleKeyGone: true}
+	d := newKeyUpdateResourceData(t, "gone-token", "team-a", "team-a")
+
+	if diags := runKeyUpdate(t, proxy, d); !diags.HasError() {
+		t.Fatal("expected an error when team_id did not change")
+	}
+	if got := atomic.LoadInt32(&proxy.generateCalls); got != 0 {
+		t.Errorf("expected no recreate when team_id is unchanged, got %d /key/generate calls", got)
+	}
+	if d.Id() != "gone-token" {
+		t.Errorf("Id = %q, want gone-token untouched on a hard failure", d.Id())
+	}
+}
+
+// A transient failure must never be mistaken for a cascade-deleted key.
+func TestResourceKeyUpdateServerErrorDoesNotRecreate(t *testing.T) {
+	proxy := &keyRecoveryProxy{
+		updateStatus: http.StatusInternalServerError,
+		updateBody:   `{"error":{"message":"Internal Server Error"}}`,
+		staleKeyGone: true,
+	}
+	d := newKeyUpdateResourceData(t, "hash-1", "team-a", "team-b")
+
+	if diags := runKeyUpdate(t, proxy, d); !diags.HasError() {
+		t.Fatal("expected a 500 to surface as an error")
+	}
+	if got := atomic.LoadInt32(&proxy.generateCalls); got != 0 {
+		t.Errorf("expected no recreate for a transient error, got %d /key/generate calls", got)
+	}
+}
+
+// The metadata pre-read fails before /key/update is ever reached when the key
+// is gone, so that path needs the same recovery.
+func TestResourceKeyUpdateRecreatesCascadeDeletedKeyWithMetadataChange(t *testing.T) {
+	proxy := &keyRecoveryProxy{updateStatus: http.StatusOK, updateBody: `{"key": "hash-1"}`, staleKeyGone: true}
+	state := &terraform.InstanceState{ID: "stale-token", Attributes: map[string]string{
+		"team_id":       "team-a",
+		"metadata.%":    "1",
+		"metadata.tier": "gold",
+	}}
+	diff := &terraform.InstanceDiff{Attributes: map[string]*terraform.ResourceAttrDiff{
+		"team_id":       {Old: "team-a", New: "team-b"},
+		"metadata.tier": {Old: "gold", New: "silver"},
+	}}
+	d, err := schema.InternalMap(resourceKey().Schema).Data(state, diff)
+	if err != nil {
+		t.Fatalf("building ResourceData returned error: %v", err)
+	}
+
+	if diags := runKeyUpdate(t, proxy, d); diags.HasError() {
+		t.Fatalf("a cascade-deleted key must be recreated, not error: %v", diags)
+	}
+	if got := atomic.LoadInt32(&proxy.updateCalls); got != 0 {
+		t.Errorf("expected the metadata pre-read to short-circuit /key/update, got %d calls", got)
+	}
+	if got := atomic.LoadInt32(&proxy.generateCalls); got != 1 {
+		t.Errorf("expected exactly 1 /key/generate recreate, got %d", got)
+	}
+	if d.Id() != "new-token" {
+		t.Errorf("Id = %q, want the recreated key's new-token", d.Id())
 	}
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Recreating a team leaves its keys pointing at a dead team
- `terraform apply` then aborts instead of moving the key
- The key resource is stuck; every later apply fails too

How it solves it:

- Tries the normal in-place key update first, as before
- On a not-found failure, re-reads the key to confirm it is gone
- Only then recreates it under the new team
- Reassigning a key between two live teams stays an in-place update

Original work by @matthowardcohere in #39747. That fork has maintainer edits turned off, so this is the same fix rebased onto current staging and pushed from a repo branch. The rebase also lets the recovery use the typed error the client gained in the meantime instead of matching on the error string.

## User Flow

Before: an operator who replaces a team hits a hard failure trying to keep that team's key in sync, and the key stays broken from then on

1. They have a team and a key whose `team_id` points at it, already applied
2. They run `terraform apply -replace=litellm_team.b`
3. Terraform destroys the old team, the gateway deletes that team's keys along with it, and the new team is created
4. Terraform sends `POST http://localhost:4077/key/update` for the key with the new team's id, and gets back `404 {"error":{"message":"Key not found.",...}}`
5. The apply aborts with `Error: error updating key: API request failed with status code 404`
6. Every apply after that fails the same way, so the operator has to delete the key from state by hand

After: the same replacement finishes cleanly, with the key moved onto the new team

1. They have the same team and key, already applied
2. They run the same `terraform apply -replace=litellm_team.b`
3. Terraform sends the same `POST http://localhost:4077/key/update` and gets the same `404`
4. It then asks `GET http://localhost:4077/key/info?key=...` to check, gets `404` back too, and sends `POST http://localhost:4077/key/generate` under the new team's id
5. The apply reports `Apply complete!` and the key line shows a new id
6. `terraform plan` straight after reports `No changes. Your infrastructure matches the configuration.`

## Relevant issues

Fixes https://github.com/BerriAI/terraform-provider-litellm/issues/12

Supersedes #39747

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: `ghcr.io/berriai/litellm-database:v1.100.1` on `http://localhost:4077` with Postgres 16 and a real `openai/gpt-4o-mini` deployment, Terraform v1.13.4, the provider built from the commit named in each heading and loaded through `dev_overrides`. Config is two teams `a` and `b` plus a `litellm_key` referencing one of them:

```hcl
provider "litellm" {
  api_base = "http://localhost:4077"
  api_key  = "sk-tfqa-1234"
}

resource "litellm_team" "a" {
  team_alias = "qa-team-a"
}

resource "litellm_team" "b" {
  team_alias = "qa-team-b"
}

resource "litellm_key" "app" {
  key_alias = "qa-app-key"
  team_id   = litellm_team.a.id
}
```

The proxy really serves traffic, so the key it mints works:

```
$ curl -s http://localhost:4077/v1/chat/completions -H "Authorization: Bearer sk-tfqa-1234" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"say ok"}]}'
{"id":"chatcmpl-ENNONyU59kbpdvqoebVpJNo48kV5E","created":1789240171,"model":"gpt-4o-mini",...,"choices":[{"finish_reason":"stop","index":0,"message":{"content":"Ok!","role":"assistant",...}}],"usage":{"completion_tokens":2,"prompt_tokens":9,...}}
```

### Before (0c98afa780)

#### Reassigning the key between two teams that both still exist

1. Started from the config above applied clean, then pointed `litellm_key.app` at `litellm_team.b` and ran `terraform apply -auto-approve`
2. Plain in-place update, same key id before and after:
   ```
   Plan: 0 to add, 1 to change, 0 to destroy.
   litellm_key.app: Modifying... [id=9af719d84ca75461e827525c7f7fafe231472212aaeef864c519b4787c2e1436]
   litellm_key.app: Modifications complete after 0s [id=9af719d84ca75461e827525c7f7fafe231472212aaeef864c519b4787c2e1436]

   Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
   ```

#### Replacing the team the key belongs to

1. Ran `terraform apply -auto-approve -replace=litellm_team.b`
2. The team was destroyed and recreated, then the key update failed:
   ```
   Plan: 1 to add, 1 to change, 1 to destroy.
   litellm_team.b: Destroying... [id=c2cd955a-d85d-4b5a-a5e1-68c1090d49ea]
   litellm_team.b: Destruction complete after 0s
   litellm_team.b: Creating...
   litellm_team.b: Creation complete after 0s [id=4ee5a9bc-fd9d-41b5-9ef4-7e5a4b828d7e]
   litellm_key.app: Modifying... [id=9af719d84ca75461e827525c7f7fafe231472212aaeef864c519b4787c2e1436]

   Error: error updating key: API request failed with status code 404: {"error":{"message":"Key not found.","type":"not_found_error","param":"key","code":"404"}}

     with litellm_key.app,
     on main.tf line 22, in resource "litellm_key" "app":
     22: resource "litellm_key" "app" {
   ```
3. Ran `terraform plan` again, and the key is still stranded, so the next apply fails the same way:
   ```
   Plan: 1 to add, 0 to change, 0 to destroy.
   ```

### After (a109553909)

#### Reassigning the key between two teams that both still exist

1. Same steps: applied clean, pointed `litellm_key.app` at `litellm_team.b`, ran `terraform apply -auto-approve`
2. Still a plain in-place update, same key id before and after, so nothing about this case changed:
   ```
   Plan: 0 to add, 1 to change, 0 to destroy.
   litellm_key.app: Modifying... [id=d29ccff5783af5052d56c09b66449209baf90f5e26c428e6c5ca8628ac93b7d8]
   litellm_key.app: Modifications complete after 0s [id=d29ccff5783af5052d56c09b66449209baf90f5e26c428e6c5ca8628ac93b7d8]

   Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
   ```

#### Replacing the team the key belongs to

1. Ran `terraform apply -auto-approve -replace=litellm_team.b`
2. The team was destroyed and recreated, and the key came back under it with a new id instead of erroring:
   ```
   Plan: 1 to add, 1 to change, 1 to destroy.
   litellm_team.b: Destroying... [id=b31116aa-2ea4-4651-acac-72cb1cbf9bce]
   litellm_team.b: Destruction complete after 0s
   litellm_team.b: Creating...
   litellm_team.b: Creation complete after 0s [id=31755e28-3be5-48c8-a32a-413e50c6cb45]
   litellm_key.app: Modifying... [id=d29ccff5783af5052d56c09b66449209baf90f5e26c428e6c5ca8628ac93b7d8]
   litellm_key.app: Modifications complete after 0s [id=dae5cac295ead1d87310ab40f7601b60653f2dfa3188d8d3b43abfe927b0de4d]

   Apply complete! Resources: 1 added, 1 changed, 1 destroyed.
   ```
3. Ran `terraform plan` again, and there is nothing left over:
   ```
   litellm_team.a: Refreshing state... [id=1cced95f-6a38-428a-a5bf-8d957273545c]
   litellm_team.b: Refreshing state... [id=31755e28-3be5-48c8-a32a-413e50c6cb45]
   litellm_key.app: Refreshing state... [id=dae5cac295ead1d87310ab40f7601b60653f2dfa3188d8d3b43abfe927b0de4d]

   No changes. Your infrastructure matches the configuration.
   ```

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Medium

- The plan says the key is updated in place, but when the recovery fires the apply really recreates it, so a proxy-generated key value is re-minted. The team's own destroy and recreate, which is what triggers this, is visible in the same plan
- A `key` value supplied in config is forwarded unchanged, so only proxy-generated values are re-minted, and only when the key was already gone

### Low

- The same cascade-delete class of bug probably exists for other parents a key can point at, `organization_id` and `user_id` among them. Left alone here until a maintainer says whether they want it extended
- The recovery costs one extra `GET /key/info`, and only on a failed update

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
