### PR TITLE
fix(http): retain handlers for active async streams

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -7,7 +7,7 @@ import ssl
 import sys
 import threading
 import time
-from collections.abc import AsyncIterable, Callable, Iterable, Mapping
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable, Mapping
 from http.cookiejar import CookieJar, DefaultCookiePolicy
 from io import BytesIO
 from types import MappingProxyType
@@ -562,6 +562,29 @@ class MaskedHTTPStatusError(httpx.HTTPStatusError):
         self.status_code = original_error.response.status_code
 
 
+class _HandlerResponseStream(httpx.AsyncByteStream):
+    def __init__(self, stream: httpx.AsyncByteStream, handler: "AsyncHTTPHandler") -> None:
+        self._stream = stream
+        self._handler: AsyncHTTPHandler | None = handler
+        self._closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        try:
+            async for chunk in self._stream:
+                yield chunk
+        finally:
+            await self.aclose()
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            await self._stream.aclose()
+        finally:
+            self._handler = None
+
+
 class AsyncHTTPHandler:
     def __init__(
         self,
@@ -772,6 +795,8 @@ class AsyncHTTPHandler:
             )
             response: Final = await self.client.send(req, stream=stream)
             response.raise_for_status()
+            if stream and isinstance(response.stream, httpx.AsyncByteStream):
+                response.stream = _HandlerResponseStream(response.stream, self)
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
@@ -976,6 +1001,8 @@ class AsyncHTTPHandler:
             )
             response: Final = await self.client.send(req, stream=stream)
             response.raise_for_status()
+            if stream and isinstance(response.stream, httpx.AsyncByteStream):
+                response.stream = _HandlerResponseStream(response.stream, self)
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -6,14 +6,18 @@ import pathlib
 import ssl
 import threading
 import weakref
+from collections.abc import AsyncIterator
+from typing import Final, Literal
 from unittest.mock import MagicMock, patch
 
 import certifi
 import httpx
 import pytest
-from aiohttp import ClientSession, TCPConnector
+import pytest_asyncio
+from aiohttp import ClientSession, TCPConnector, web
 
 import litellm
+from litellm.caching.llm_caching_handler import LLMClientCache
 from litellm.llms.custom_httpx.aiohttp_transport import LiteLLMAiohttpTransport
 from litellm.llms.custom_httpx.http_handler import (
     _CLIENT_REFCOUNT_WHEN_HANDLER_IS_SOLE_REFERRER,
@@ -23,6 +27,79 @@ from litellm.llms.custom_httpx.http_handler import (
     _get_httpx_client,
     get_ssl_configuration,
 )
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def gated_response_server() -> AsyncIterator[tuple[str, asyncio.Event]]:
+    release_body: Final = asyncio.Event()
+
+    async def serve(request: web.Request) -> web.StreamResponse:
+        response: Final = web.StreamResponse()
+        await response.prepare(request)
+        await release_body.wait()
+        try:
+            await response.write(b"complete response")
+        except ConnectionResetError:
+            pass
+        return response
+
+    app: Final = web.Application()
+    app.router.add_route("*", "/", serve)
+    runner: Final = web.AppRunner(app)
+    await runner.setup()
+    site: Final = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    try:
+        yield f"http://127.0.0.1:{runner.addresses[0][1]}/", release_body
+    finally:
+        release_body.set()
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ("post", "delete"))
+@pytest.mark.parametrize("disable_aiohttp", (False, True))
+@pytest.mark.parametrize("finish", ("complete", "close", "cancel"))
+async def test_stream_outlives_expired_handler_and_releases_it_when_closed(
+    gated_response_server: tuple[str, asyncio.Event],
+    monkeypatch: pytest.MonkeyPatch,
+    method: Literal["post", "delete"],
+    disable_aiohttp: bool,
+    finish: Literal["complete", "close", "cancel"],
+) -> None:
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", disable_aiohttp)
+    monkeypatch.setattr(litellm, "force_ipv4", False)
+    url, release_body = gated_response_server
+    cache: Final = LLMClientCache()
+
+    async def start_request() -> tuple[httpx.Response, weakref.ReferenceType[AsyncHTTPHandler]]:
+        handler: Final = AsyncHTTPHandler()
+        cache.set_cache("stream", handler, litellm_owned_client=True, ttl=0)
+        response: Final = await (
+            handler.post(url, stream=True) if method == "post" else handler.delete(url, stream=True)
+        )
+        return response, weakref.ref(handler)
+
+    response, handler_ref = await start_request()
+    assert cache.get_cache("stream") is None
+    await asyncio.sleep(0)
+    try:
+        if finish == "complete":
+            release_body.set()
+            assert await asyncio.wait_for(response.aread(), timeout=2) == b"complete response"
+        elif finish == "cancel":
+            reading: Final = asyncio.create_task(response.aread())
+            await asyncio.sleep(0)
+            reading.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await reading
+        else:
+            await response.aclose()
+    finally:
+        await response.aclose()
+    gc.collect()
+    await asyncio.sleep(0)
+    assert handler_ref() is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cache expiry can interrupt active streaming responses

How it solves it:

- Retain each handler until its streamed response closes
- Release it on completion, explicit close, or cancellation

## User Flow

Before: a streaming chat request stops producing output while another request succeeds

1. Send POST http://127.0.0.1:43991/v1/chat/completions with `stream: true`, `max_tokens: 512`, and a prompt to count from 1 to 100000
2. After the first content arrives, send the same URL a second streaming request asking for exactly `OK`
3. The second request returns `OK`, but the first stays at HTTP 200 without a final chunk or token usage and eventually reaches the client's deadline

After: both requests complete with their final chunks and token usage

1. Send POST http://127.0.0.1:43991/v1/chat/completions with `stream: true`, `max_tokens: 512`, and a prompt to count from 1 to 100000
2. After the first content arrives, send the same URL a second streaming request asking for exactly `OK`
3. The second request returns `OK`, and the first completes with 512 output tokens and `finish_reason: length`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves one specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting maintainer review

The 12 new regression cases cover POST and DELETE, both async transports, and completion, explicit close, and cancellation. Six fail on the previous implementation. All 113 targeted tests and `make check` pass locally

All reported CI and coverage checks now pass at the current PR tip. The provider job ran all 12 new cases successfully, and its [coverage artifact](https://github.com/BerriAI/litellm/actions/runs/34716558931/artifacts/10305100856) covers all 22 changed executable lines

All committers have signed the CLA. This PR remains a draft because the required Greptile, Veria, and Bugbot reviews have not been verified.

## Screenshots / Proof of Fix

Both revisions ran a local proxy against the same real GLM-5.3-Flash vLLM server with thinking disabled. The changed production module was loaded from the named commit before each proxy started. The before commit is the merge base; the after commit is the current PR tip

For this reproduction only, set `http_handler._DEFAULT_TTL_FOR_HTTPX_CLIENTS = 1` after importing `litellm.llms.custom_httpx.http_handler` and before starting the proxy. This accelerates the normal one-hour cache expiry without changing the eviction grace or cleanup behavior. The PR does not change the default TTL

Proxy configuration, with `GLM_API_BASE` pointing to the real vLLM server:

```yaml
model_list:
  - model_name: glm-5.3-flash
    litellm_params:
      model: hosted_vllm/GLM-5.3-Flash-EXL3
      api_base: os.environ/GLM_API_BASE
      api_key: local-backend
      timeout: 1800
      stream_timeout: 1800
      extra_body:
        chat_template_kwargs:
          enable_thinking: false
litellm_settings:
  request_timeout: 900
  sse_keepalive_ping_interval_seconds: 15
  drop_params: true
  num_retries: 0
router_settings:
  num_retries: 0
general_settings:
  master_key: sk-local-canary-only
  background_health_checks: false
```

Each case uses its own `long.json` and `short.json`. Both contain `model: glm-5.3-flash`, `stream: true`, and `temperature: 0`. The long prompt asks `Count from 1 to 100000. Output only numbers separated by spaces. Do not stop early.`; the short prompt asks `Reply exactly OK.`. Each prompt also has a fresh run identifier to avoid prefix-cache reuse

| Endpoint | Prompt field | Long / short output limits | Other fields |
|---|---|---|---|
| `/v1/chat/completions` | `messages: [{role: user, content: prompt}]` | `max_tokens: 512` / `16` | `stream_options: {include_usage: true}` |
| `/v1/responses` | `input: prompt` | `max_output_tokens: 512` / `16` | `store: false` |
| `/v1/messages` | `messages: [{role: user, content: prompt}]` | `max_tokens: 512` / `16` | None |

Run the two curl commands in separate terminals. Submit the short request after the long stream has produced content and at least 1.25 seconds have elapsed. The results below include curl's HTTP status and elapsed time, plus normalized finish and usage information parsed from the saved SSE. All short requests completed before the long curl process ended. These runs shared the backend with two active agent sessions; the timings are observations, not a throughput comparison

### Before (49f94cf8320c837e13a70bf24c14d7a17ea3ed84)

#### /v1/chat/completions

1. Start the long request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/chat/completions -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @long.json --output long.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

2. Start the short request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/chat/completions -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @short.json --output short.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

3. Observed output

   ```json
   {
     "long": {
       "http_code": 200,
       "time_total": 180.004567,
       "curl_exit": 28,
       "finish": null,
       "output_tokens": null
     },
     "short": {
       "http_code": 200,
       "time_total": 4.042451,
       "curl_exit": 0,
       "finish": "stop",
       "output_tokens": 2,
       "text": "OK"
     },
     "short_finished_before_long": true
   }
   ```

4. The long stream stopped at `1` without a finish event or usage; curl exited with deadline code 28

#### /v1/responses

1. Start the long request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/responses -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @long.json --output long.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

2. Start the short request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/responses -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @short.json --output short.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

3. Observed output

   ```json
   {
     "long": {
       "http_code": 200,
       "time_total": 40.632281,
       "curl_exit": 0,
       "finish": "length",
       "output_tokens": 512
     },
     "short": {
       "http_code": 200,
       "time_total": 3.279703,
       "curl_exit": 0,
       "finish": "stop",
       "output_tokens": 2,
       "text": "OK"
     },
     "short_finished_before_long": true
   }
   ```

4. This endpoint completed on the baseline and serves as a compatibility check

#### /v1/messages

1. Start the long request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/messages -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @long.json --output long.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

2. Start the short request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/messages -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @short.json --output short.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

3. Observed output

   ```json
   {
     "long": {
       "http_code": 200,
       "time_total": 180.00624,
       "curl_exit": 28,
       "finish": null,
       "output_tokens": null
     },
     "short": {
       "http_code": 200,
       "time_total": 0.695225,
       "curl_exit": 0,
       "finish": "stop",
       "output_tokens": 2,
       "text": "OK"
     },
     "short_finished_before_long": true
   }
   ```

4. The long stream stopped at `1 2 3 4 5 6 7 8 9` without a finish event or usage; curl exited with deadline code 28

### After (f0f28728b92054754e6d82b56cf6ec8e21a21125)

#### /v1/chat/completions

1. Start the long request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/chat/completions -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @long.json --output long.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

2. Start the short request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/chat/completions -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @short.json --output short.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

3. Observed output

   ```json
   {
     "long": {
       "http_code": 200,
       "time_total": 21.812215,
       "curl_exit": 0,
       "finish": "length",
       "output_tokens": 512
     },
     "short": {
       "http_code": 200,
       "time_total": 3.386337,
       "curl_exit": 0,
       "finish": "stop",
       "output_tokens": 2,
       "text": "OK"
     },
     "short_finished_before_long": true
   }
   ```

#### /v1/responses

1. Start the long request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/responses -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @long.json --output long.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

2. Start the short request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/responses -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @short.json --output short.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

3. Observed output

   ```json
   {
     "long": {
       "http_code": 200,
       "time_total": 13.169853,
       "curl_exit": 0,
       "finish": "length",
       "output_tokens": 512
     },
     "short": {
       "http_code": 200,
       "time_total": 0.709238,
       "curl_exit": 0,
       "finish": "stop",
       "output_tokens": 2,
       "text": "OK"
     },
     "short_finished_before_long": true
   }
   ```

#### /v1/messages

1. Start the long request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/messages -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @long.json --output long.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

2. Start the short request

   ```bash
   curl --silent --show-error --no-buffer --max-time 180 http://127.0.0.1:43991/v1/messages -H 'Authorization: Bearer sk-local-canary-only' -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' --data-binary @short.json --output short.sse --write-out '{"http_code":%{http_code},"time_total":%{time_total}}'
   ```

3. Observed output

   ```json
   {
     "long": {
       "http_code": 200,
       "time_total": 46.167426,
       "curl_exit": 0,
       "finish": "length",
       "output_tokens": 512
     },
     "short": {
       "http_code": 200,
       "time_total": 37.117932,
       "curl_exit": 0,
       "finish": "stop",
       "output_tokens": 2,
       "text": "OK"
     },
     "short_finished_before_long": true
   }
   ```

### Deployed endurance validation (September 13, 2026)

The production v1.98.0 backport of the stream-ownership repair remained running through a 5-hour 16-minute 57-second native Hermes qualification, with the normal 3,600-second handler-cache TTL unchanged. Two persistent agents completed 251 and 249 independently verified file jobs, including eight and seven automatic compressions. Both final audits passed; full terminal scans found no provider or compression errors, and the proxy retained the same container identity with zero restarts or OOM events. This validates the combined deployed stack under that workload; the accelerated-expiry before/after reproduction above isolates this bug.

## Type

Bug Fix

## Caveats (if any)

### Low

- Live reproduction covered the default aiohttp transport
- Both transports have completion, close, and cancellation regression tests
- Required automated reviews remain unverified

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
