### PR TITLE
fix(ui): populate create key user dropdown by default

### DIFF
--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.integration.test.tsx
@@ -884,6 +884,50 @@ describe("CreateKey", () => {
   });
 
   describe("user search debounce", () => {
+    it("should offer users without typing and assign the selected owner to the key", async () => {
+      vi.mocked(userFilterUICall).mockResolvedValue([
+        { user_id: "u-77", user_email: "alice@example.com" },
+        { user_id: "u-no-email", user_email: null },
+      ]);
+      await openModal();
+      await nameTheKey();
+      await userEvent.click(screen.getByRole("radio", { name: "Another User" }));
+      await userEvent.click(await userSearchInput());
+
+      expect(await screen.findByRole("option", { name: /^u-no-email$/ })).toBeInTheDocument();
+      await userEvent.click(await screen.findByRole("option", { name: "alice@example.com (u-77)" }));
+      await submit();
+
+      expect((await createdPayload()).user_id).toBe("u-77");
+    });
+
+    it("should keep filtered users when the initial list arrives after a search", async () => {
+      const answers = new Map<string, (users: { user_id: string; user_email: string }[]) => void>();
+      vi.mocked(userFilterUICall).mockImplementation(
+        (_accessToken, params) =>
+          new Promise((resolve) => {
+            answers.set(params.get("user_email") ?? "", resolve);
+          }) as never,
+      );
+      renderCreateKey({ autoOpenCreate: true, prefillData: { owned_by: "another_user" } });
+      const search = await userSearchInput();
+      await userEvent.click(search);
+      await screen.findByText("Searching...");
+      await userEvent.type(search, "alice");
+      await waitFor(() => expect(answers.has("alice")).toBe(true));
+
+      await act(async () => {
+        answers.get("alice")?.([{ user_id: "u-77", user_email: "alice@example.com" }]);
+      });
+      await screen.findByRole("option", { name: "alice@example.com (u-77)" });
+      await act(async () => {
+        answers.get("")?.([{ user_id: "u-88", user_email: "bob@example.com" }]);
+      });
+
+      expect(screen.queryByRole("option", { name: "bob@example.com (u-88)" })).not.toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "alice@example.com (u-77)" })).toBeInTheDocument();
+    });
+
     it("fires exactly one search carrying the last typed value", async () => {
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -892,14 +936,24 @@ describe("CreateKey", () => {
         const search = await userSearchInput();
 
         await user.type(search, "ali");
-        expect(vi.mocked(userFilterUICall)).not.toHaveBeenCalled();
+        expect(
+          vi
+            .mocked(userFilterUICall)
+            .mock.calls.map(([, params]) => params.get("user_email"))
+            .filter(Boolean),
+        ).toEqual([]);
 
         await user.type(search, "ce");
-        await vi.advanceTimersByTimeAsync(400);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(400);
+        });
 
-        expect(vi.mocked(userFilterUICall)).toHaveBeenCalledTimes(1);
-        const params = vi.mocked(userFilterUICall).mock.calls[0][1] as URLSearchParams;
-        expect(params.get("user_email")).toBe("alice");
+        expect(
+          vi
+            .mocked(userFilterUICall)
+            .mock.calls.map(([, params]) => params.get("user_email"))
+            .filter(Boolean),
+        ).toEqual(["alice"]);
       } finally {
         vi.useRealTimers();
       }
@@ -937,14 +991,16 @@ describe("CreateKey", () => {
       expect(screen.getByRole("option", { name: "alice.smith@example.com (u-smith)" })).toBeInTheDocument();
     });
 
-    it("stops searching once the box is cleared and the abandoned search answers", async () => {
+    it("should restore default users when cleared and ignore the abandoned search", async () => {
       const answers = new Map<string, (users: { user_id: string; user_email: string }[]) => void>();
-      vi.mocked(userFilterUICall).mockImplementation(
-        (_accessToken, params) =>
-          new Promise((resolve) => {
-            answers.set(params.get("user_email") ?? "", resolve);
-          }) as never,
-      );
+      vi.mocked(userFilterUICall).mockImplementation((_accessToken, params) => {
+        if (!params.get("user_email")) {
+          return Promise.resolve([{ user_id: "u-88", user_email: "bob@example.com" }]) as never;
+        }
+        return new Promise((resolve) => {
+          answers.set(params.get("user_email") ?? "", resolve);
+        }) as never;
+      });
 
       const user = userEvent.setup();
       renderCreateKey({ autoOpenCreate: true, prefillData: { owned_by: "another_user" } });
@@ -952,17 +1008,15 @@ describe("CreateKey", () => {
 
       await user.type(search, "ali");
       await waitFor(() => expect(answers.has("ali")).toBe(true), { timeout: 3000 });
-      await screen.findByText("Searching...");
-
       await user.clear(search);
-      await screen.findByText("No users found");
+      await screen.findByRole("option", { name: "bob@example.com (u-88)" });
 
       await act(async () => {
         answers.get("ali")?.([{ user_id: "u-jones", user_email: "alice.jones@example.com" }]);
       });
 
       expect(screen.queryByRole("option", { name: "alice.jones@example.com (u-jones)" })).not.toBeInTheDocument();
-      expect(screen.getByText("No users found")).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "bob@example.com (u-88)" })).toBeInTheDocument();
     });
 
     it("keeps searching while a newer search is still in flight", async () => {
@@ -1040,7 +1094,7 @@ describe("CreateKey", () => {
         answers.get("alice.smith@example.comx")?.reject(new Error("search failed"));
       });
 
-      expect(toast.fromError).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(toast.fromError).toHaveBeenCalledTimes(1));
     });
   });
 
@@ -1067,13 +1121,21 @@ describe("CreateKey", () => {
         const search = await userSearchInput();
 
         await user.type(search, "alice");
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(400);
+        });
         await user.click(await screen.findByRole("option", { name: "alice@example.com (u-77)" }));
         await act(async () => {
           await vi.advanceTimersByTimeAsync(1000);
         });
 
         expect(search).toHaveValue("alice@example.com (u-77)");
-        expect(vi.mocked(userFilterUICall)).toHaveBeenCalledTimes(1);
+        expect(
+          vi
+            .mocked(userFilterUICall)
+            .mock.calls.map(([, params]) => params.get("user_email"))
+            .filter(Boolean),
+        ).toEqual(["alice"]);
       } finally {
         vi.useRealTimers();
       }

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -7,7 +7,7 @@ import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings"
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import useCan from "@/app/(dashboard)/hooks/useCan";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
@@ -160,7 +160,7 @@ interface CreateKeyProps {
 
 interface User {
   user_id: string;
-  user_email: string;
+  user_email: string | null;
   role?: string;
 }
 
@@ -259,9 +259,23 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [isCreateUserModalVisible, setIsCreateUserModalVisible] = useState(false);
   const [possibleUIRoles, setPossibleUIRoles] = useState<Record<string, Record<string, string>>>({});
-  const [userOptions, setUserOptions] = useState<SearchSelectOption[]>([]);
-  const [userSearchLoading, setUserSearchLoading] = useState<boolean>(false);
-  const latestUserSearchRef = useRef(0);
+  const [userSearch, setUserSearch] = useState("");
+  const userQueryOptions = {
+    queryKey: ["create-key-users", accessToken, userSearch],
+    queryFn: () => userFilterUICall(accessToken!, new URLSearchParams(userSearch ? { user_email: userSearch } : {})),
+    enabled: accessToken != null && isModalVisible && keyOwner === "another_user",
+    retry: false,
+    staleTime: 0,
+  };
+  const {
+    data: users = [],
+    isFetching: userSearchLoading,
+    error: userSearchError,
+  } = useQuery<User[]>(userQueryOptions);
+  const userOptions: SearchSelectOption[] = users.map((user) => ({
+    label: user.user_email ? `${user.user_email} (${user.user_id})` : user.user_id,
+    value: user.user_id,
+  }));
   const [disabledCallbacks, setDisabledCallbacks] = useState<string[]>([]);
   const [keyType, setKeyType] = useState<string>("llm_api");
   const [modelAliases, setModelAliases] = useState<{ [key: string]: string }>({});
@@ -280,6 +294,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
   const selectedModels: string[] = (useWatch({ control: form.control, name: "models" }) as string[] | undefined) ?? [];
   const handleCancel = () => {
     setIsModalVisible(false);
+    setUserSearch("");
     setApiKey(null);
     setSelectedCreateKeyTeam(null);
     form.reset(formDefaults);
@@ -555,41 +570,9 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
     setIsCreateUserModalVisible(false);
   };
 
-  const fetchUsers = async (searchText: string): Promise<void> => {
-    const searchId = latestUserSearchRef.current + 1;
-    latestUserSearchRef.current = searchId;
-    const isLatestSearch = (): boolean => searchId === latestUserSearchRef.current;
-
-    if (!searchText) {
-      setUserOptions([]);
-      setUserSearchLoading(false);
-      return;
-    }
-
-    setUserSearchLoading(true);
-    try {
-      const params = new URLSearchParams();
-      params.append("user_email", searchText); // Always search by email
-      if (accessToken == null) {
-        return;
-      }
-      const response = await userFilterUICall(accessToken, params);
-      if (!isLatestSearch()) return;
-
-      const data: User[] = response;
-      const options: SearchSelectOption[] = data.map((user) => ({
-        label: `${user.user_email} (${user.user_id})`,
-        value: user.user_id,
-      }));
-
-      setUserOptions(options);
-    } catch (error) {
-      console.error("Error fetching users:", error);
-      if (isLatestSearch()) toast.fromError("Failed to search for users");
-    } finally {
-      if (isLatestSearch()) setUserSearchLoading(false);
-    }
-  };
+  useEffect(() => {
+    if (userSearchError) toast.fromError("Failed to search for users");
+  }, [userSearchError]);
 
   const changeOrganization = (write: FieldWrite) => (orgId: string | null) => {
     write(orgId);
@@ -678,7 +661,10 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                   <RadioGroup
                     className="flex flex-wrap items-center gap-4"
                     value={keyOwner}
-                    onValueChange={(value: unknown) => setKeyOwner(String(value))}
+                    onValueChange={(value: unknown) => {
+                      setKeyOwner(String(value));
+                      setUserSearch("");
+                    }}
                   >
                     <label className={KEY_OWNER_LABEL_CLASS}>
                       <RadioGroupItem value="you" />
@@ -726,7 +712,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                             options={userOptions}
                             value={typeof control.value === "string" ? control.value : undefined}
                             onValueChange={control.onChange}
-                            onSearchChange={fetchUsers}
+                            onSearchChange={setUserSearch}
                             isLoading={userSearchLoading}
                             placeholder="Type email to search for users"
                             emptyText="No users found"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Create Key offers no users until someone types
- Clearing the search removes all user choices

How it solves it:

- Load the first 50 recent users automatically
- Restore defaults on clear and ignore abandoned search responses

## User Flow

Before: an admin must type before any users appear

1. Open `https://<proxy-host>/ui/` and click **Create New Key**
2. Choose **Another User** and open **User ID**
3. See **No users found** until typing an email fragment
4. Clear the search and see an empty list again

After: an admin can choose a user immediately

1. Open `https://<proxy-host>/ui/` and click **Create New Key**
2. Choose **Another User** and open **User ID**
3. See recent users, or type an email fragment to filter
4. Clear the search and see recent users again

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is isolated to one problem
- [x] Greptile has posted 5/5 for the current head

## Screenshots / Proof of Fix

Real browser, Next development server, live proxy, and seeded PostgreSQL with 10 users, signed in as a proxy admin

Screenshots were captured locally for both revisions; attachment upload is pending because the available GitHub browser session is signed out

### Before (559247fa84ad37e1d23a3915dcd1dc50d765043d)

#### Default choices

1. Open `http://127.0.0.1:63930/ui/`, click **Create New Key**, then **Another User**
2. Open **User ID** without typing: **No users found** (`before-default.png`)

#### Search and selection

1. Type `admin`: three matching users appear (`before-search.png`)
2. Select `admin@test.local (e2e-proxy-admin)` and blur: selection remains (`before-selection.png`)

### After (0218dc326f0f9cf1f6b2fb6fb77d460b3ee91c7b)

#### Default choices

1. Open `http://127.0.0.1:52933/ui/`, click **Create New Key**, then **Another User**
2. Tab to **User ID** and press Down without typing: 10 users appear, including the user without email (`after-default.png`)
3. Clear a selected user and reopen: all 10 choices return (`after-clear.png`)

#### Search and selection

1. Press Escape, then type `admin`: three matching users appear (`after-search.png`)
2. Select `admin@test.local (e2e-proxy-admin)` and blur: selection remains (`after-selection.png`)
3. Paste `viewer`, wait for results, press Down and Enter, then Tab: `adminviewer@test.local (e2e-admin-viewer)` remains selected (`after-paste-keyboard.png`)

<details>
<summary>Supporting checks</summary>

- `vitest run src/components/organisms/create_key_button.integration.test.tsx src/components/shared/PaginatedSearchSelect.integration.test.tsx`: 101 passed, one existing expected failure
- New regression cases failed before the fix; disabling empty-query loading made three committed regression cases fail
- Scratch tests independently covered keyboard selection and owner submission, paste and blur, and ownership switching: three passed
- Five independent review lenses found no blocking defects
- Changed-file Prettier and ESLint checks passed; existing warnings remain
- Full lint counts are within every existing warning budget
- Full TypeScript check reports the same 1,847 diagnostic lines on unchanged staging and this revision, with zero new diagnostics
- Full ESLint exits on an unused suppression in unchanged router settings; the same failure reproduces against the unchanged file and suppression baseline
- [UI test CI](https://github.com/BerriAI/litellm/actions/runs/34718204931): 891 passed and three expected failures across 34 files, including all 81 CreateKey integration tests; four additional type-contract tests passed
- [Shipped dashboard build](https://github.com/BerriAI/litellm/actions/runs/34718204929) and [frontend lint with budgets](https://github.com/BerriAI/litellm/actions/runs/34718204858) passed
- [Greptile review](https://github.com/BerriAI/litellm/pull/40896#issuecomment-5648616947): 5/5 for the current head, no actionable findings
- Production build and the full repository test suite were not run locally

</details>

## Type

Bug Fix

## Caveats (if any)

### Medium

- Screenshot attachment upload remains pending
- Required CI passed; additional CI jobs remain pending

### Low

- Default choices use the existing 50-user endpoint limit
- Full TypeScript and lint have confirmed unchanged baseline failures
- Production build is not locally verified

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
