### PR TITLE
fix(anthropic): map content_filter finish reason to refusal stop_reason

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1365,8 +1365,10 @@ class LiteLLMAnthropicMessagesAdapter:
             return "end_turn"
         elif openai_finish_reason == "length":
             return "max_tokens"
-        elif openai_finish_reason == "tool_calls":
+        elif openai_finish_reason in ("tool_calls", "function_call"):
             return "tool_use"
+        elif openai_finish_reason in ("content_filter", "guardrail_intervened", "refusal"):
+            return "refusal"
         return "end_turn"
 
     @staticmethod
@@ -1521,7 +1523,11 @@ class LiteLLMAnthropicMessagesAdapter:
             usage=anthropic_usage,
             content=anthropic_content,
             stop_reason=anthropic_finish_reason,
-            stop_details=(refusal_stop_details(refusal_text) if anthropic_finish_reason == "refusal" else None),
+            stop_details=(
+                refusal_stop_details(refusal_text)
+                if anthropic_finish_reason == "refusal" and refusal_text is not None
+                else None
+            ),
         )
 
         applied_edits: Final = polyfill_result.applied_edits_for_response() if polyfill_result else None

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -102,6 +102,71 @@ def test_translate_chat_length_takes_precedence_over_refusal():
     assert result.get("stop_details") is None
 
 
+def test_translate_chat_content_filter_finish_reason_maps_to_refusal():
+    # Issue #40857: content_filter without refusal text must map to stop_reason="refusal"
+    response = ModelResponse(
+        id="chatcmpl-content-filter",
+        model="openai-model",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="content_filter",
+                message=Message(content=None, role="assistant"),
+            )
+        ],
+        usage=Usage(prompt_tokens=12, completion_tokens=0, total_tokens=12),
+    )
+
+    result = LiteLLMAnthropicMessagesAdapter().translate_openai_response_to_anthropic(response)
+
+    assert result["stop_reason"] == "refusal"
+    assert result.get("stop_details") is None
+
+
+def test_translate_chat_content_filter_with_refusal_text():
+    response = ModelResponse(
+        id="chatcmpl-content-filter-with-refusal",
+        model="openai-model",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="content_filter",
+                message=Message(content=None, role="assistant", refusal="Violation of safety policy"),
+            )
+        ],
+        usage=Usage(prompt_tokens=12, completion_tokens=0, total_tokens=12),
+    )
+
+    result = LiteLLMAnthropicMessagesAdapter().translate_openai_response_to_anthropic(response)
+
+    assert result["stop_reason"] == "refusal"
+    assert result.get("stop_details") == {
+        "type": "refusal",
+        "category": None,
+        "explanation": "Violation of safety policy",
+    }
+
+
+def test_translate_chat_finish_reason_refusal():
+    response = ModelResponse(
+        id="chatcmpl-refusal-finish-reason",
+        model="openai-model",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="refusal",
+                message=Message(content=None, role="assistant"),
+            )
+        ],
+        usage=Usage(prompt_tokens=12, completion_tokens=0, total_tokens=12),
+    )
+
+    result = LiteLLMAnthropicMessagesAdapter().translate_openai_response_to_anthropic(response)
+
+    assert result["stop_reason"] == "refusal"
+    assert result.get("stop_details") is None
+
+
 def test_translate_streaming_openai_chunk_to_anthropic_content_block():
     choices = [
         StreamingChoices(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
@@ -238,6 +238,40 @@ async def test_streaming_chat_length_takes_precedence_over_refusal(async_mode: b
     assert "stop_details" not in message_delta["delta"]
 
 
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.asyncio
+async def test_streaming_chat_content_filter_emits_refusal_stop_reason(async_mode: bool):
+    # Issue #40857: content_filter without refusal text must emit stop_reason="refusal"
+    chunks = [
+        _make_chunk(Delta(content=None, role="assistant"), finish_reason="content_filter"),
+    ]
+    stream = _AsyncStream(chunks) if async_mode else iter(chunks)
+    wrapper = AnthropicStreamWrapper(completion_stream=stream, model="openai-model")
+
+    events = await _drain_async(wrapper) if async_mode else _drain_sync(wrapper)
+
+    message_delta = next(event for event in events if event["type"] == "message_delta")
+    assert message_delta["delta"]["stop_reason"] == "refusal"
+    assert "stop_details" not in message_delta["delta"]
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.asyncio
+async def test_streaming_chat_content_filter_with_refusal_text_emits_stop_details(async_mode: bool):
+    chunks = [
+        _make_chunk(Delta(content=None, refusal="Policy violation")),
+        _make_chunk(Delta(content=None), finish_reason="content_filter"),
+    ]
+    stream = _AsyncStream(chunks) if async_mode else iter(chunks)
+    wrapper = AnthropicStreamWrapper(completion_stream=stream, model="openai-model")
+
+    events = await _drain_async(wrapper) if async_mode else _drain_sync(wrapper)
+
+    message_delta = next(event for event in events if event["type"] == "message_delta")
+    assert message_delta["delta"]["stop_reason"] == "refusal"
+    assert message_delta["delta"]["stop_details"]["explanation"] == "Policy violation"
+
+
 def _input_json_deltas(events: List[dict]) -> List[str]:
     return [
         e["delta"]["partial_json"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Upstream content-filtered turns (`finish_reason="content_filter"`) arrive on `/v1/messages` with `stop_reason: "end_turn"`.
- Clients speaking the Anthropic Messages API cannot distinguish a blocked answer from an ordinary one.

How it solves it:

- Maps `content_filter`, `guardrail_intervened`, and `refusal` finish reasons to Anthropic `stop_reason: "refusal"` in `_translate_openai_finish_reason_to_anthropic`.
- Maps `function_call` to `tool_use`.
- In `translate_openai_response_to_anthropic`, only sets `stop_details` when `refusal_text` is present.

## User Flow

Before: a developer whose agent framework speaks the Anthropic Messages API cannot tell a blocked answer from an ordinary one, so the agent retries on a request the provider refused

1. They send `POST https://litellm-domain/v1/messages` with a prompt the upstream provider content-filters
2. The response arrives with HTTP 200, `"content": []`, and `"stop_reason": "end_turn"`
3. With `"stream": true`, the final `message_delta` chunk also carries `"stop_reason": "end_turn"`
4. Their agent loop sees `end_turn` and treats the blocked turn as a normal completion

After: the same requests return `stop_reason: "refusal"` so the agent recognizes the refusal

1. They send `POST https://litellm-domain/v1/messages` with a prompt the upstream provider content-filters
2. The response arrives with HTTP 200, `"content": []`, and `"stop_reason": "refusal"`
3. With `"stream": true`, the final `message_delta` chunk carries `"stop_reason": "refusal"`
4. Their agent loop sees `stop_reason: "refusal"` and halts or handles the policy refusal appropriately

## Relevant issues

Fixes #40857

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type

🐛 Bug Fix

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
