### PR TITLE
fix(github_copilot): stop retrying 401s

### DIFF
--- a/litellm/llms/github_copilot/authenticator.py
+++ b/litellm/llms/github_copilot/authenticator.py
@@ -145,6 +145,14 @@ class Authenticator:
             verbose_logger.warning("Error reading API endpoint from file: %s", e)
             return None
 
+    def _invalidate_access_token(self) -> None:
+        """Delete the cached access token so the next get_access_token() can re-login."""
+        try:
+            os.remove(self.access_token_file)
+            verbose_logger.warning("Invalidated cached GitHub Copilot access token")
+        except OSError:
+            pass
+
     def _refresh_api_key(self) -> dict[str, Any]:
         """
         Refresh the API key using the access token.
@@ -155,12 +163,11 @@ class Authenticator:
         Raises:
             RefreshAPIKeyError: If unable to refresh the API key.
         """
-        access_token: Final = self.get_access_token()
-        headers: Final = self._get_github_headers(access_token)
         api_key_url: Final = os.getenv("GITHUB_COPILOT_API_KEY_URL", DEFAULT_GITHUB_API_KEY_URL)
-
         max_retries: Final = 3
         for attempt in range(max_retries):
+            access_token: Final = self.get_access_token()
+            headers: Final = self._get_github_headers(access_token)
             try:
                 sync_client = _get_httpx_client()
                 response = sync_client.get(api_key_url, headers=headers)
@@ -173,8 +180,27 @@ class Authenticator:
                 else:
                     verbose_logger.warning("API key response missing token: %s", response_json)
             except httpx.HTTPStatusError as e:
-                verbose_logger.error("HTTP error refreshing API key (attempt %s/%s): %s", attempt + 1, max_retries, e)
-            except Exception as e:
+                status: Final = e.response.status_code
+                verbose_logger.error(
+                    "HTTP error refreshing API key (attempt %s/%s): %s",
+                    attempt + 1,
+                    max_retries,
+                    e,
+                )
+                if status in (401, 403):
+                    verbose_logger.warning(
+                        "Access token rejected by GitHub (%s), invalidating cached token",
+                        status,
+                    )
+                    self._invalidate_access_token()
+                    continue
+                if status == 429 or status >= 500:
+                    continue
+                raise RefreshAPIKeyError(
+                    message=f"HTTP error refreshing API key: {e}",
+                    status_code=status,
+                )
+            except httpx.RequestError as e:
                 verbose_logger.error("Unexpected error refreshing API key: %s", e)
 
         raise RefreshAPIKeyError(


### PR DESCRIPTION
## TLDR

Problem this solves:

- GitHub Copilot auth stays wedged after a 401
- The proxy retries a dead token until you delete files by hand

How it solves it:

- Treat 401/403 as a real auth answer
- Drop the cached token and re-login; retry only 429/5xx/network

## User Flow

Before: Copilot through the proxy dies after sleep/wake and never recovers

1. They authenticate GitHub Copilot once and requests succeed
2. The machine sleeps long enough that GitHub rejects the token with 401
3. The next Copilot request fails, retries the same dead token, and stays broken until they delete `~/.config/litellm/github_copilot`

After: a 401 forces a fresh login instead of a retry loop

1. Same setup, same sleep/wake
2. The next Copilot request gets 401, drops the cached token, and prompts device login again
3. After they complete GitHub login, Copilot requests succeed without deleting files by hand

## Relevant issues

Relates to #25312

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix
