### PR TITLE
fix(proxy): make /ui redirects path-relative behind untrusted-proxy TLS termination

### DIFF
--- a/litellm/proxy/middleware/admission_control_middleware.py
+++ b/litellm/proxy/middleware/admission_control_middleware.py
@@ -10,6 +10,7 @@ from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from litellm._logging import verbose_proxy_logger
+from litellm.proxy.middleware.route_path_utils import get_route_path
 
 _EXEMPT_PATHS: Final[frozenset[str]] = frozenset(
     {
@@ -147,7 +148,7 @@ class AdmissionControlMiddleware:
             return
 
         settings: Final = self.get_settings()
-        if settings is None or _get_route_path(scope) in _EXEMPT_PATHS:
+        if settings is None or get_route_path(scope) in _EXEMPT_PATHS:
             await self.app(scope, receive, send)
             return
 
@@ -183,19 +184,6 @@ class AdmissionControlMiddleware:
         finally:
             semaphore.release()
             state.record_release()
-
-
-def _get_route_path(scope: Scope) -> str:
-    """Strip the ASGI root_path (SERVER_ROOT_PATH) the same way Starlette does before route matching."""
-    path: Final[str] = scope["path"]
-    root_path: Final[str] = scope.get("root_path", "")
-    if not root_path or not path.startswith(root_path):
-        return path
-    if path == root_path:
-        return ""
-    if path[len(root_path)] == "/":
-        return path[len(root_path) :]
-    return path
 
 
 def _create_gauge(gauge_type: Callable[..., object], name: str, description: str) -> _Gauge:

--- a/litellm/proxy/middleware/route_path_utils.py
+++ b/litellm/proxy/middleware/route_path_utils.py
@@ -1,0 +1,19 @@
+"""Shared ASGI scope helper for middleware that needs the request path Starlette
+will actually route on, i.e. with any ``SERVER_ROOT_PATH``/``root_path`` prefix
+stripped the same way Starlette's own router does before matching."""
+
+from typing import Final
+
+from starlette.types import Scope
+
+
+def get_route_path(scope: Scope) -> str:
+    path: Final[str] = scope["path"]
+    root_path: Final[str] = scope.get("root_path", "")
+    if not root_path or not path.startswith(root_path):
+        return path
+    if path == root_path:
+        return ""
+    if path[len(root_path)] == "/":
+        return path[len(root_path) :]
+    return path

--- a/litellm/proxy/middleware/ui_relative_redirect_middleware.py
+++ b/litellm/proxy/middleware/ui_relative_redirect_middleware.py
@@ -1,0 +1,77 @@
+"""Relativizes same-origin Location headers on redirects under the /ui mount.
+
+Starlette's own trailing-slash redirect (``Router.app``) and ``StaticFiles``'s
+directory-index redirect both build the ``Location`` header from
+``scope["scheme"]``. That scheme is only "https" when uvicorn's
+``ProxyHeadersMiddleware`` trusts the request's peer IP enough to honor
+``X-Forwarded-Proto`` (``FORWARDED_ALLOW_IPS``, default loopback-only).
+Behind a TLS-terminating load balancer whose peer IP isn't trusted, this
+bakes the plaintext-hop scheme into an absolute ``http://...`` redirect,
+which browsers refuse to follow off an https page (LIT-7455).
+
+Rewriting a same-origin ``Location`` to be path-relative removes the scheme
+dependency entirely: the browser resolves a relative ``Location`` against
+the page's own (correct) scheme. Only ``Location`` values whose host matches
+the request's own ``Host`` header are touched, so an intentionally
+cross-origin redirect elsewhere in the app (e.g. SSO) is never affected.
+"""
+
+from typing import Final
+from urllib.parse import SplitResult, urlsplit, urlunsplit
+
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from litellm.proxy.middleware.route_path_utils import get_route_path
+
+_REDIRECT_STATUS_CODES: Final[frozenset[int]] = frozenset({301, 302, 303, 307, 308})
+
+
+def _request_host(scope: Scope) -> str | None:
+    for key, value in scope["headers"]:
+        if key == b"host":
+            return value.decode("latin-1")
+    return None
+
+
+def _relativize_same_origin(location: str, host: str) -> str:
+    parts: Final[SplitResult] = urlsplit(location)
+    if not parts.scheme and not parts.netloc:
+        return location  # already relative
+    if parts.netloc.lower() != host.lower():
+        return location  # cross-origin: leave untouched
+    path: Final = parts.path or "/"
+    if not path.startswith("/") or path.startswith("//"):
+        # Not a normal absolute path (or would be interpreted as
+        # protocol-relative once the scheme/netloc are dropped); safest to
+        # leave the Location as-is rather than risk changing its target.
+        return location
+    return urlunsplit(("", "", path, parts.query, parts.fragment))
+
+
+class UiRelativeRedirectMiddleware:
+    """Rewrites same-origin Location headers on /ui responses to be path-relative."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        route_path: Final = get_route_path(scope) if scope["type"] == "http" else ""
+        if not (route_path == "/ui" or route_path.startswith("/ui/")):
+            await self.app(scope, receive, send)
+            return
+
+        host: Final = _request_host(scope)
+
+        async def send_with_relative_location(message: Message) -> None:
+            is_redirect_start: Final = (
+                message["type"] == "http.response.start" and message["status"] in _REDIRECT_STATUS_CODES
+            )
+            if host is not None and is_redirect_start:
+                headers: Final = MutableHeaders(scope=message)
+                location: Final = headers.get("location")
+                if location is not None:
+                    headers["location"] = _relativize_same_origin(location, host)
+            await send(message)
+
+        await self.app(scope, receive, send_with_relative_location)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -632,6 +632,9 @@ from litellm.proxy.middleware.request_size_limit_middleware import (
 from litellm.proxy.middleware.security_headers_middleware import (
     SecurityHeadersMiddleware,
 )
+from litellm.proxy.middleware.ui_relative_redirect_middleware import (
+    UiRelativeRedirectMiddleware,
+)
 from litellm.proxy.ocr_endpoints.endpoints import router as ocr_router
 from litellm.proxy.openai_files_endpoints.files_endpoints import (
     router as openai_files_router,
@@ -2218,6 +2221,11 @@ app.add_middleware(
 )
 app.add_middleware(InFlightRequestsMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
+# LIT-7455: /ui redirects (the mount's trailing-slash redirect and
+# StaticFiles' directory-index redirect) hardcode scope["scheme"], which is
+# wrong behind a TLS-terminating LB unless FORWARDED_ALLOW_IPS trusts the
+# LB's peer IP. Relativizing same-origin Locations removes that dependency.
+app.add_middleware(UiRelativeRedirectMiddleware)
 
 
 def mount_swagger_ui():

--- a/tests/test_litellm/proxy/middleware/test_ui_relative_redirect_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_ui_relative_redirect_middleware.py
@@ -1,0 +1,215 @@
+"""
+Tests for UiRelativeRedirectMiddleware (LIT-7455).
+
+Regression coverage for: behind a TLS-terminating load balancer whose peer IP
+isn't in uvicorn's FORWARDED_ALLOW_IPS, scope["scheme"] stays "http" even
+though the original request was https, and the /ui mount's trailing-slash and
+directory-index redirects bake that wrong scheme into an absolute Location.
+These tests drive the real StaticFiles mount (not a mock) with a scope built
+the same way that bug reports it -- scheme="http", Host header the client
+actually used -- and assert the emitted Location no longer carries a scheme
+or host at all, so the browser resolves it against its own (correct) origin.
+"""
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import RedirectResponse
+from starlette.routing import Route
+
+from litellm.proxy.middleware.ui_relative_redirect_middleware import (
+    UiRelativeRedirectMiddleware,
+)
+
+
+def _ui_app(tmp_path):
+    ui_root = tmp_path / "ui"
+    ui_root.mkdir()
+    (ui_root / "index.html").write_text("index")
+    nested = ui_root / "teams"
+    nested.mkdir()
+    (nested / "index.html").write_text("teams")
+
+    app = FastAPI()
+    app.mount("/ui", StaticFiles(directory=str(ui_root), html=True), name="ui")
+    app.add_middleware(UiRelativeRedirectMiddleware)
+    return app
+
+
+def _client_behind_untrusted_lb(app):
+    """A TestClient that talks plain http to the app but claims an https Host,
+    mirroring a request that reached an untrusted-peer uvicorn over the
+    plaintext LB->container hop after the LB terminated TLS."""
+    return TestClient(app, base_url="http://ui.example.com")
+
+
+def test_is_pure_asgi_not_base_http_middleware():
+    """BaseHTTPMiddleware buffers the whole response; this must be pure ASGI
+    so it keeps streaming responses (e.g. the SSE proxy paths) intact."""
+    assert not issubclass(UiRelativeRedirectMiddleware, BaseHTTPMiddleware)
+    assert "__call__" in UiRelativeRedirectMiddleware.__dict__
+
+
+def test_bare_ui_trailing_slash_redirect_is_relative(tmp_path):
+    """The router's own /ui -> /ui/ redirect must no longer carry a scheme/host."""
+    client = _client_behind_untrusted_lb(_ui_app(tmp_path))
+
+    response = client.get("/ui", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/ui/"
+
+
+def test_nested_route_directory_index_redirect_is_relative(tmp_path):
+    """StaticFiles' own directory-index redirect (e.g. /ui/teams -> /ui/teams/)
+    is a second, independent code path that must also be relativized."""
+    client = _client_behind_untrusted_lb(_ui_app(tmp_path))
+
+    response = client.get("/ui/teams", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/ui/teams/"
+
+
+def test_relativized_redirect_is_actually_followable(tmp_path):
+    """The whole point: a client that refuses to follow a scheme-downgraded
+    absolute redirect must still be able to follow the relative one."""
+    client = _client_behind_untrusted_lb(_ui_app(tmp_path))
+
+    landed = client.get("/ui", follow_redirects=True)
+
+    assert landed.status_code == 200
+    assert landed.text == "index"
+
+
+def test_query_string_and_fragment_preserved(tmp_path):
+    ui_root = tmp_path / "ui"
+    ui_root.mkdir()
+    nested = ui_root / "mcp" / "oauth" / "callback"
+    nested.mkdir(parents=True)
+    (nested / "index.html").write_text("callback")
+
+    app = FastAPI()
+    app.mount("/ui", StaticFiles(directory=str(ui_root), html=True), name="ui")
+    app.add_middleware(UiRelativeRedirectMiddleware)
+    client = _client_behind_untrusted_lb(app)
+
+    response = client.get(
+        "/ui/mcp/oauth/callback?code=abc&state=xyz", follow_redirects=False
+    )
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/ui/mcp/oauth/callback/?code=abc&state=xyz"
+
+
+def test_paths_outside_ui_mount_are_untouched():
+    """The middleware must not relativize redirects on unrelated routes."""
+
+    async def redirect_elsewhere(request):
+        return RedirectResponse(url="https://ui.example.com/somewhere-else", status_code=307)
+
+    app = FastAPI(routes=[Route("/not-ui", redirect_elsewhere)])
+    app.add_middleware(UiRelativeRedirectMiddleware)
+    client = TestClient(app, base_url="https://ui.example.com")
+
+    response = client.get("/not-ui", follow_redirects=False)
+
+    assert response.headers["location"] == "https://ui.example.com/somewhere-else"
+
+
+def test_cross_origin_ui_redirect_is_left_absolute():
+    """A /ui redirect to a genuinely different host (e.g. an external IdP)
+    must never be rewritten -- only same-origin Locations are in scope."""
+
+    async def redirect_to_idp(request):
+        return RedirectResponse(url="https://idp.example.com/authorize", status_code=307)
+
+    app = FastAPI(routes=[Route("/ui/login", redirect_to_idp)])
+    app.add_middleware(UiRelativeRedirectMiddleware)
+    client = TestClient(app, base_url="https://ui.example.com")
+
+    response = client.get("/ui/login", follow_redirects=False)
+
+    assert response.headers["location"] == "https://idp.example.com/authorize"
+
+
+def test_protocol_relative_path_is_left_untouched():
+    """A Location whose path would become //host/... once scheme/netloc are
+    dropped must be left alone: stripping them would make it protocol-relative
+    and let the browser pick a different host."""
+
+    async def redirect_weird_path(request):
+        return RedirectResponse(
+            url="https://ui.example.com//evil.example.com/x", status_code=307
+        )
+
+    app = FastAPI(routes=[Route("/ui/weird", redirect_weird_path)])
+    app.add_middleware(UiRelativeRedirectMiddleware)
+    client = TestClient(app, base_url="https://ui.example.com")
+
+    response = client.get("/ui/weird", follow_redirects=False)
+
+    assert response.headers["location"] == "https://ui.example.com//evil.example.com/x"
+
+
+def test_userinfo_in_netloc_does_not_match_host_header():
+    """scheme://user@host is netloc "user@host", which must not string-match
+    the bare Host header -- confirms the comparison can't be tricked into
+    treating a foreign-looking netloc as same-origin."""
+
+    async def redirect_with_userinfo(request):
+        return RedirectResponse(
+            url="https://evil.example.com@ui.example.com/x", status_code=307
+        )
+
+    app = FastAPI(routes=[Route("/ui/x", redirect_with_userinfo)])
+    app.add_middleware(UiRelativeRedirectMiddleware)
+    client = TestClient(app, base_url="https://ui.example.com")
+
+    response = client.get("/ui/x", follow_redirects=False)
+
+    assert response.headers["location"] == "https://evil.example.com@ui.example.com/x"
+
+
+def test_host_header_match_is_case_insensitive():
+    async def redirect_upper(request):
+        return RedirectResponse(url="HTTPS://UI.EXAMPLE.COM/ui/", status_code=307)
+
+    app = FastAPI(routes=[Route("/ui", redirect_upper)])
+    app.add_middleware(UiRelativeRedirectMiddleware)
+    client = TestClient(app, base_url="https://ui.example.com")
+
+    response = client.get("/ui", follow_redirects=False)
+
+    assert response.headers["location"] == "/ui/"
+
+
+def test_already_relative_location_is_unchanged():
+    async def redirect_relative(request):
+        return RedirectResponse(url="/ui/login", status_code=307)
+
+    app = FastAPI(routes=[Route("/ui/x", redirect_relative)])
+    app.add_middleware(UiRelativeRedirectMiddleware)
+    client = TestClient(app, base_url="https://ui.example.com")
+
+    response = client.get("/ui/x", follow_redirects=False)
+
+    assert response.headers["location"] == "/ui/login"
+
+
+def test_non_redirect_ui_response_is_unaffected(tmp_path):
+    ui_root = tmp_path / "ui"
+    ui_root.mkdir()
+    (ui_root / "index.html").write_text("index")
+
+    app = FastAPI()
+    app.mount("/ui", StaticFiles(directory=str(ui_root), html=True), name="ui")
+    app.add_middleware(UiRelativeRedirectMiddleware)
+    client = _client_behind_untrusted_lb(app)
+
+    response = client.get("/ui/")
+
+    assert response.status_code == 200
+    assert response.text == "index"
+    assert "location" not in response.headers


### PR DESCRIPTION
## TLDR

Problem this solves:

- Behind a TLS-terminating load balancer, `GET /ui` redirects to `http://...`
- Browsers refuse the https to http downgrade, so the Admin UI never loads
- Every nested UI route (`/ui/teams`, `/ui/mcp/oauth/callback`) hits the same redirect
- Only workaround today is setting `FORWARDED_ALLOW_IPS` to the LB subnets

How it solves it:

- New middleware, scoped to `/ui`, rewrites same-origin `Location` headers to be path-relative
- The browser resolves a relative `Location` against its own (correct) https origin
- Cross-origin redirects (SSO, external IdP) are left untouched
- Nothing outside `/ui` is affected

## User Flow

Before: an admin whose proxy sits behind an AWS ALB (HTTPS in, plain HTTP to the container) cannot open the Admin UI

1. They open https://litellm-domain/ui in a browser
2. The proxy answers 307 with `location: http://litellm-domain:4000/ui/`
3. The browser refuses to follow an https page's redirect to plain http, so they see a blank page or a mixed-content error
4. The same happens for every deep link, e.g. https://litellm-domain/ui/teams redirects to `http://litellm-domain:4000/ui/teams/`

After: the same admin opens the Admin UI with no proxy env changes

1. They open https://litellm-domain/ui in a browser
2. The proxy answers 307 with `location: /ui/`
3. The browser resolves that against https://litellm-domain and loads https://litellm-domain/ui/ normally
4. Deep links behave the same way: https://litellm-domain/ui/teams redirects to `/ui/teams/` and loads

## Relevant issues

## Linear ticket

Resolves LIT-7455

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Proxy started from the repo with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port 4111`. No `FORWARDED_ALLOW_IPS` set, so this is the same untrusted-peer situation as the ticket: uvicorn sees a plain http connection and does not trust any forwarded headers

### Before (b1360efc2f)

#### Bare /ui

1. `curl -sI http://127.0.0.1:4111/ui | grep -iE '^(HTTP|location)'`
2. Output:
   ```
   HTTP/1.1 307 Temporary Redirect
   location: http://127.0.0.1:4111/ui/
   ```

#### Nested UI route

1. `curl -sI http://127.0.0.1:4111/ui/teams | grep -iE '^(HTTP|location)'`
2. Output:
   ```
   HTTP/1.1 307 Temporary Redirect
   location: http://127.0.0.1:4111/ui/teams/
   ```

### After (cea59a45c2)

#### Bare /ui

1. `curl -sI http://127.0.0.1:4111/ui | grep -iE '^(HTTP|location)'`
2. Output:
   ```
   HTTP/1.1 307 Temporary Redirect
   location: /ui/
   ```

#### Nested UI route

1. `curl -sI http://127.0.0.1:4111/ui/teams | grep -iE '^(HTTP|location)'`
2. Output:
   ```
   HTTP/1.1 307 Temporary Redirect
   location: /ui/teams/
   ```

Query strings survive too, which matters for the MCP OAuth callback page:

1. `curl -sI 'http://127.0.0.1:4111/ui/mcp/oauth/callback?code=abc&state=xyz' | grep -iE '^(HTTP|location)'`
2. Output:
   ```
   HTTP/1.1 307 Temporary Redirect
   location: /ui/mcp/oauth/callback/?code=abc&state=xyz
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Only `Location` values whose host exactly matches the request `Host` header are rewritten
  - A redirect to a different host, a `//host/...` path, or a `user@host` netloc is left as-is
- `FORWARDED_ALLOW_IPS` is still the right fix for anything else that reads the request scheme (e.g. generated absolute URLs); this PR removes the dependency only for `/ui` redirects
- The pre-existing "lazy OpenAPI snapshot is stale" `make check` failure is a `RateLimitError` docstring diff on the default branch, unrelated to this change, so the snapshot was left alone here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to `/ui` redirect `Location` rewriting with explicit guards for cross-origin and odd URLs; admission control only refactors path resolution with no behavior change intended.
> 
> **Overview**
> Fixes **Admin UI load failures behind TLS-terminating load balancers** when uvicorn does not trust forwarded headers (LIT-7455). Starlette/StaticFiles redirects under `/ui` were emitting absolute `http://...` `Location` values; browsers block that from HTTPS pages.
> 
> Adds **`UiRelativeRedirectMiddleware`**, registered on the proxy app, which intercepts redirect responses only for `/ui` routes and rewrites **same-origin** `Location` headers to path-relative URLs (query/fragment preserved). Cross-origin redirects, non-`/ui` routes, and suspicious paths (`//...`, userinfo netloc) are left unchanged. Implementation is **pure ASGI** (no response buffering).
> 
> Extracts shared **`get_route_path`** into `route_path_utils.py` and switches admission control exempt-path checks to use it (replacing a local duplicate).
> 
> Adds regression tests covering trailing-slash and directory-index redirects via real `StaticFiles`, followability, and safety edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea59a45c2aaca2fb47dc58944a20f44700db0d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->