### PR TITLE
fix(ci): update OCR lifecycle test path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1086,7 +1086,7 @@ jobs:
             mkdir -p test-results
             TEST_FILES=$(printf "%s\n%s\n" \
               "$(circleci tests glob "tests/ocr_tests/**/test_*.py")" \
-              "tests/test_litellm/ocr/test_rust_bridge.py")
+              "tests/test_litellm/rust_bridge/test_ocr_lifecycle.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
               --command="tr ' ' '\\n' | awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \


### PR DESCRIPTION
## TLDR

Problem this solves:

- OCR CI stops before running any tests
- Its test list references a file deleted in #40734

How it solves it:

- Select the replacement OCR lifecycle tests
- Keep the existing provider tests and parallel execution

## User Flow

Before: a contributor opens the OCR CI job and sees zero tests run

1. Open the CircleCI workflow for a staging change
2. Open `ocr_testing`
3. See `4 workers [0 items]` and missing coverage warnings

After: the contributor gets OCR test results from the same job

1. Open the CircleCI workflow for a staging change
2. Open `ocr_testing`
3. See provider and lifecycle tests execute

## Relevant issues

[Failed OCR job](https://app.circleci.com/pipelines/gh/BerriAI/litellm/89533/workflows/20c49a67-8602-48fa-9272-3d0c0f879381/jobs/2174652)

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] Greptile has independently posted 5/5 for the current head

Existing lifecycle coverage passes: 23 tests. The complete job selection collects 56 tests. CircleCI configuration validation passes. Local verification used Python 3.13; CI runs Python 3.12. The scoped local lint entrypoint has no checks for this configuration-only change

## Screenshots / Proof of Fix

### Before (d4a72e737232b72bd4a820580da6acc97805c88c)

1. Open [OCR job 2174652](https://app.circleci.com/pipelines/gh/BerriAI/litellm/89533/workflows/20c49a67-8602-48fa-9272-3d0c0f879381/jobs/2174652)
2. Expand Run tests: `4 workers [0 items]`, `no tests ran in 30.38s`, then exit status 123

### After (f5a7b548c8873c57ffe7586e1b132caddfa68f36)

1. Open [OCR job 2174770](https://app.circleci.com/workflow/a60fdadb-b7e3-48a1-8b18-09d8da82c6e1/job/09da024e-1d2c-4e93-9389-6c2e2cbf7f4e)
2. Expand Run tests: `4 workers [56 items]`; 48 passed and 8 skipped
3. Confirm the job succeeded, including coverage rename, test-results upload, and workspace persistence

## Type

Bug Fix
Infrastructure

## Caveats (if any)

### Low

- Eight OCR tests remain skipped in CI
- Other repository checks are still running

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
