### PR TITLE
test(auth): freeze the in-memory cache clock in the Postgres prefetch tests

### DIFF
--- a/tests/proxy_behavior/auth/test_auth_object_prefetch.py
+++ b/tests/proxy_behavior/auth/test_auth_object_prefetch.py
@@ -28,6 +28,10 @@ def _dead_db() -> MagicMock:
     return prisma
 
 
+def _frozen_cache() -> UserApiKeyCache:
+    return UserApiKeyCache(in_memory_cache=InMemoryCache(clock=lambda: 0.0), redis_cache=None)
+
+
 async def test_join_binds_the_membership_to_the_requested_team(prisma):
     """A user in two teams with different member budgets must get the requested team's row."""
     run = uuid4().hex
@@ -58,7 +62,7 @@ async def test_join_binds_the_membership_to_the_requested_team(prisma):
             data={"user_id": user_id, "team_id": team_b, "litellm_budget_table": {"connect": {"budget_id": f"b-{run}"}}}
         )
 
-        cache = UserApiKeyCache(in_memory_cache=InMemoryCache(), redis_cache=None)
+        cache = _frozen_cache()
         refs = AuthObjectRefs(user_id=user_id, team_id=team_a, membership_user_id=user_id, organization_id=org_id)
         await prefetch_auth_objects(refs=refs, user_api_key_cache=cache, prisma_client=prisma)
 
@@ -100,7 +104,7 @@ async def test_join_reads_team_model_aliases_from_the_mapped_column(prisma):
             where={"team_id": team_id}, include={"litellm_model_table": True}
         )
 
-        cache = UserApiKeyCache(in_memory_cache=InMemoryCache(), redis_cache=None)
+        cache = _frozen_cache()
         refs = AuthObjectRefs(user_id=None, team_id=team_id, membership_user_id=None, organization_id=None)
         await prefetch_auth_objects(refs=refs, user_api_key_cache=cache, prisma_client=prisma)
 
@@ -144,7 +148,7 @@ async def test_join_reads_null_nested_lists_the_way_prisma_does(prisma):
             where={"user_id_team_id": {"user_id": user_id, "team_id": team_id}}, include={"litellm_budget_table": True}
         )
 
-        cache = UserApiKeyCache(in_memory_cache=InMemoryCache(), redis_cache=None)
+        cache = _frozen_cache()
         refs = AuthObjectRefs(user_id=user_id, team_id=team_id, membership_user_id=user_id, organization_id=None)
         await prefetch_auth_objects(refs=refs, user_api_key_cache=cache, prisma_client=prisma)
 

--- a/tests/test_litellm/proxy/auth/test_auth_object_prefetch.py
+++ b/tests/test_litellm/proxy/auth/test_auth_object_prefetch.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException
 
 from litellm.caching.in_memory_cache import InMemoryCache
 from litellm.caching.redis_cache import RedisCache
+from litellm.constants import DEFAULT_IN_MEMORY_TTL
 from litellm.proxy._types import (
     LiteLLM_OrganizationTable,
     LiteLLM_TeamMembership,
@@ -131,6 +132,17 @@ def _cache(redis: RedisCache | None) -> UserApiKeyCache:
 
 def _refs() -> AuthObjectRefs:
     return AuthObjectRefs.from_token(UserAPIKeyAuth(token="t", user_id=USER_ID, team_id=TEAM_ID, org_id=ORG_ID))
+
+
+class _MutableClock:
+    def __init__(self) -> None:
+        self.now = 1_000_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
 
 
 async def _read_all_through_getters(
@@ -335,4 +347,20 @@ async def test_no_redis_goes_straight_to_one_query():
     await prefetch_auth_objects(refs=_refs(), user_api_key_cache=cache, prisma_client=prisma)
 
     assert prisma.db.query_first.await_count == 1
+    assert cache.in_memory_cache.get_cache(f"team_membership:{USER_ID}:{TEAM_ID}") is not None
+
+
+@pytest.mark.asyncio
+async def test_org_entries_expire_with_default_in_memory_ttl_while_the_membership_reservation_does_not():
+    clock = _MutableClock()
+    cache = UserApiKeyCache(in_memory_cache=InMemoryCache(clock=clock), redis_cache=None)
+
+    await prefetch_auth_objects(refs=_refs(), user_api_key_cache=cache, prisma_client=_prisma())
+
+    assert cache.in_memory_cache.get_cache(f"org_id:{ORG_ID}") is not None
+    assert cache.in_memory_cache.get_cache(f"team_membership:{USER_ID}:{TEAM_ID}") is not None
+
+    clock.advance(DEFAULT_IN_MEMORY_TTL + 1)
+
+    assert cache.in_memory_cache.get_cache(f"org_id:{ORG_ID}") is None
     assert cache.in_memory_cache.get_cache(f"team_membership:{USER_ID}:{TEAM_ID}") is not None


### PR DESCRIPTION
## TLDR
- Postgres prefetch test fails intermittently on staging and PRs
- Org cache entries live `DEFAULT_IN_MEMORY_TTL` (5s); loaded runners can outlive them
- Expired entry hits the dead DB mock → `TypeError: object MagicMock can't be used in 'await' expression`
- Freeze the test cache clock; the join assertions themselves are unchanged

## User Flow
**Before**: a contributor opens a green-locally PR and Postgres Tests is red with a TypeError that names no real code path; they burn a rerun and a bisect before concluding it isn't theirs.
**After**: the suite's verdict depends on what the SQL returns, not on how many seconds the runner needed — the same PR stays red only when the join is actually wrong.

## Proof of Fix
1. Before @ `e2409975` (staging tip): [run 34731962425](https://github.com/BerriAI/litellm/actions/runs/34731962425) and [run 34731671116](https://github.com/BerriAI/litellm/actions/runs/34731671116) each fail exactly one test with that TypeError at the `get_org_object` call, while the three earlier getters were served from the prefetch cache.
2. Mechanism, isolated deterministically via the injected cache clock: prefetch, advance the clock past `DEFAULT_IN_MEMORY_TTL`, call the four getters with a dead prisma mock → the first three still hit, `get_org_object` falls back and raises the identical error (at 4.9s all four hit; at 5.1s it fails). The new `test_org_entries_expire_with_default_in_memory_ttl_while_the_membership_reservation_does_not` pins that boundary.
3. After @ `70d9bf9`: the Postgres tests build the cache as `InMemoryCache(clock=lambda: 0.0)`, so no entry can expire mid-test regardless of runner load.
4. `pytest tests/test_litellm/proxy/auth/test_auth_object_prefetch.py` → 12 passed; the Postgres file collects and skips cleanly without `DATABASE_URL`; the Postgres suite itself runs in this PR's CI.

## Type
🧪 Test

## Caveats
- 🟢 Green: none — no runtime code touched.
- 🟡 Yellow: the other two Postgres tests in the file read only 60s/600s entries today; they get the frozen clock too, which removes the same stall class on very slow runners.
