### PR TITLE
fix(prompt-management): compose vector retrieval with Anthropic caching

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1023,25 +1023,38 @@ class Logging(LiteLLMLoggingBaseClass):
             dynamic_callback_params=self.standard_callback_dynamic_params,
         )
 
-        if custom_logger:
-            breakpoints_before: Final = AnthropicCacheControlHook.count_request_cache_breakpoints(messages)
-            (
-                model,
-                messages,
-                non_default_params,
-            ) = await custom_logger.async_get_chat_completion_prompt(
-                model=model,
-                messages=messages,
-                non_default_params=non_default_params or {},
-                prompt_id=prompt_id,
-                prompt_spec=prompt_spec,
-                prompt_variables=prompt_variables,
-                dynamic_callback_params=self.standard_callback_dynamic_params,
-                litellm_logging_obj=self,
+        vector_store_logger: Final = (
+            self._get_vector_store_pre_call_hook()
+            if isinstance(custom_logger, AnthropicCacheControlHook)
+            and litellm.vector_store_registry is not None
+            and litellm.vector_store_registry.get_vector_store_ids_to_run(
+                non_default_params=non_default_params,
                 tools=tools,
-                prompt_label=prompt_label,
-                prompt_version=prompt_version,
             )
+            else None
+        )
+        prompt_loggers: Final = tuple(logger for logger in (vector_store_logger, custom_logger) if logger is not None)
+
+        if prompt_loggers:
+            breakpoints_before: Final = AnthropicCacheControlHook.count_request_cache_breakpoints(messages)
+            for prompt_logger in prompt_loggers:
+                (
+                    model,
+                    messages,
+                    non_default_params,
+                ) = await prompt_logger.async_get_chat_completion_prompt(
+                    model=model,
+                    messages=messages,
+                    non_default_params=non_default_params or {},
+                    prompt_id=prompt_id,
+                    prompt_spec=prompt_spec,
+                    prompt_variables=prompt_variables,
+                    dynamic_callback_params=self.standard_callback_dynamic_params,
+                    litellm_logging_obj=self,
+                    tools=tools,
+                    prompt_label=prompt_label,
+                    prompt_version=prompt_version,
+                )
             if request_kwargs is not None:
                 AnthropicCacheControlHook.record_gateway_injection(
                     request_kwargs,
@@ -1177,18 +1190,25 @@ class Logging(LiteLLMLoggingBaseClass):
         # Vector Store / Knowledge Base hooks
         #########################################################
         if litellm.vector_store_registry is not None:
-            vector_store_custom_logger: Final = _init_custom_logger_compatible_class(
-                logging_integration="vector_store_pre_call_hook",
-                internal_usage_cache=None,
-                llm_router=None,
-            )
-            self.model_call_details["prompt_integration"] = vector_store_custom_logger.__class__.__name__
-            # Add to global callbacks so post-call hooks are invoked
-            if vector_store_custom_logger and vector_store_custom_logger not in litellm.callbacks:
-                litellm.logging_callback_manager.add_litellm_callback(vector_store_custom_logger)
-            return vector_store_custom_logger
+            vector_store_custom_logger: Final = self._get_vector_store_pre_call_hook()
+            if vector_store_custom_logger is not None:
+                self.model_call_details["prompt_integration"] = vector_store_custom_logger.__class__.__name__
+                return vector_store_custom_logger
 
         return None
+
+    @staticmethod
+    def _get_vector_store_pre_call_hook() -> CustomLogger | None:
+        vector_store_custom_logger: Final = _init_custom_logger_compatible_class(
+            logging_integration="vector_store_pre_call_hook",
+            internal_usage_cache=None,
+            llm_router=None,
+        )
+        if vector_store_custom_logger is None:
+            return None
+        if vector_store_custom_logger not in litellm.callbacks:
+            litellm.logging_callback_manager.add_litellm_callback(vector_store_custom_logger)
+        return vector_store_custom_logger
 
     def get_custom_logger_for_anthropic_cache_control_hook(self, non_default_params: dict) -> CustomLogger | None:
         if non_default_params.get("cache_control_injection_points", None):

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -6100,6 +6100,7 @@ async def test_prompt_hooks_compose_vector_search_with_anthropic_cache_control(
     )
     db_fallback = None
     if not registered_in_memory:
+
         async def resolve_from_db(**kwargs: object) -> list[LiteLLM_ManagedVectorStore]:
             non_default_params = kwargs["non_default_params"]
             assert isinstance(non_default_params, dict)
@@ -6143,6 +6144,7 @@ async def test_prompt_hooks_compose_vector_search_with_anthropic_cache_control(
     assert "cache_control_injection_points" in params
 
     try:
+        assert logging_obj._get_vector_store_pre_call_hook() is vector_store_hook
         _, messages, remaining_params = await logging_obj.async_get_chat_completion_prompt(
             model=model,
             messages=messages,

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -6094,6 +6094,10 @@ async def test_prompt_hooks_compose_vector_search_with_anthropic_cache_control(
     )
     from litellm.vector_stores.vector_store_registry import VectorStoreRegistry
 
+    with monkeypatch.context() as no_hook:
+        no_hook.setattr(logging_module, "_init_custom_logger_compatible_class", MagicMock(return_value=None))
+        assert logging_obj._get_vector_store_pre_call_hook() is None
+
     vector_store = LiteLLM_ManagedVectorStore(vector_store_id="vs_123", custom_llm_provider="bedrock")
     registry = VectorStoreRegistry(
         vector_stores=[vector_store] if registered_in_memory else [],

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -6074,6 +6074,98 @@ def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_pa
             )
         for hook in [cb for cb in litellm.callbacks if isinstance(cb, VectorStorePreCallHook)]:
             litellm.logging_callback_manager.remove_callback_from_list_by_object(litellm.callbacks, hook)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("registered_in_memory", [True, False], ids=["memory", "database-fallback"])
+async def test_prompt_hooks_compose_vector_search_with_anthropic_cache_control(
+    logging_obj, monkeypatch, registered_in_memory
+):
+    from litellm.integrations.anthropic_cache_control_hook import AnthropicCacheControlHook
+    from litellm.integrations.vector_store_integrations.vector_store_pre_call_hook import (
+        VectorStorePreCallHook,
+    )
+    from litellm.litellm_core_utils import litellm_logging as logging_module
+    from litellm.types.vector_stores import (
+        LiteLLM_ManagedVectorStore,
+        VectorStoreResultContent,
+        VectorStoreSearchResponse,
+        VectorStoreSearchResult,
+    )
+    from litellm.vector_stores.vector_store_registry import VectorStoreRegistry
+
+    vector_store = LiteLLM_ManagedVectorStore(vector_store_id="vs_123", custom_llm_provider="bedrock")
+    registry = VectorStoreRegistry(
+        vector_stores=[vector_store] if registered_in_memory else [],
+    )
+    db_fallback = None
+    if not registered_in_memory:
+        async def resolve_from_db(**kwargs: object) -> list[LiteLLM_ManagedVectorStore]:
+            non_default_params = kwargs["non_default_params"]
+            assert isinstance(non_default_params, dict)
+            non_default_params.pop("vector_store_ids", None)
+            return [vector_store]
+
+        db_fallback = AsyncMock(side_effect=resolve_from_db)
+        monkeypatch.setattr(registry, "pop_vector_stores_to_run_with_db_fallback", db_fallback)
+    monkeypatch.setattr(litellm, "vector_store_registry", registry)
+    monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+    search: Final = AsyncMock(
+        return_value=VectorStoreSearchResponse(
+            object="vector_store.search_results.page",
+            search_query="What does the handbook say?",
+            data=[
+                VectorStoreSearchResult(
+                    score=1.0,
+                    content=[VectorStoreResultContent(text="Refunds take seven days", type="text")],
+                )
+            ],
+        )
+    )
+    router = MagicMock()
+    router.avector_store_search = search
+    runtime = MagicMock()
+    runtime.llm_router.return_value = router
+    runtime.prisma_client.return_value = None
+    vector_store_hook = VectorStorePreCallHook(proxy_runtime=runtime)
+    previous_loggers = tuple(logging_module._in_memory_loggers)
+    logging_module._in_memory_loggers.clear()
+    logging_module._in_memory_loggers.append(vector_store_hook)
+    model = "bedrock/anthropic.claude-3-5-haiku-20241022-v1:0"
+    messages = [{"role": "user", "content": "What does the handbook say?"}]
+    params = {"custom_llm_provider": "bedrock", "vector_store_ids": ["vs_123"]}
+    AnthropicCacheControlHook.maybe_seed_default_injection_points(
+        non_default_params=params,
+        messages=messages,
+        model=model,
+        custom_llm_provider="bedrock",
+    )
+    assert "cache_control_injection_points" in params
+
+    try:
+        _, messages, remaining_params = await logging_obj.async_get_chat_completion_prompt(
+            model=model,
+            messages=messages,
+            non_default_params=params,
+            prompt_variables=None,
+        )
+
+        search.assert_awaited_once()
+        assert messages[0]["content"] == "Context:\n\nRefunds take seven days\n\n"
+        assert messages[1]["content"] == "What does the handbook say?"
+        assert messages[1]["cache_control"] == {"type": "ephemeral"}
+        assert "vector_store_ids" not in remaining_params
+        assert "cache_control_injection_points" not in remaining_params
+        if db_fallback is not None:
+            db_fallback.assert_awaited_once()
+    finally:
+        litellm.logging_callback_manager.remove_callback_from_list_by_object(
+            litellm.callbacks, vector_store_hook, require_self=False
+        )
+        logging_module._in_memory_loggers.clear()
+        logging_module._in_memory_loggers.extend(previous_loggers)
+
+
 def test_newrelic_dispatch_prefers_otel_v2_when_flag_on(monkeypatch):
     """With LITELLM_OTEL_V2 on and operator credentials present, the "newrelic"
     callback builds the OTel v2 logger (per-team credential routing); with the


### PR DESCRIPTION
## TLDR

Problem this solves:

- Automatic Anthropic caching skips configured vector-store retrieval
- Bedrock rejects leaked `vector_store_ids` with HTTP 400

How it solves it:

- Run vector retrieval before cache-control injection
- Preserve database fallback and post-call vector callbacks

## User Flow

Before: a developer using automatic Anthropic caching with a Bedrock knowledge base gets an error instead of a grounded answer

1. The proxy admin enables `enable_anthropic_prompt_caching` and configures a Bedrock model with a registered vector store
2. The developer sends `POST https://litellm-domain/v1/chat/completions` with that model and a normal user message
3. The proxy returns HTTP 400 with `vector_store_ids: Extra inputs are not permitted`, and no knowledge-base answer is produced

After: the same request retrieves knowledge-base context and keeps automatic prompt caching

1. The proxy admin uses the same caching and vector-store configuration
2. The developer sends the same `POST https://litellm-domain/v1/chat/completions` request
3. The vector store is searched before cache controls are applied, so `vector_store_ids` is consumed and the request can return a grounded completion

## Relevant issues

Fixes #40908

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The relevant prompt-management, cache-control, and vector-store test files pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Delays in PR merge?

If review is delayed, I will use the LiteLLM Slack #pr-review channel

## Screenshots / Proof of Fix

Pending a credential-backed Bedrock knowledge-base run against a live proxy

This PR remains draft until the same request is captured on the base commit and current tip with real retrieval and cache-write/cache-read evidence

## Developer verification

### Before (e240997529)

1. Run the new regression against the merge base
2. The vector-store search is awaited 0 times and the test fails

### After (1cb147dd25)

1. Run the same regression for in-memory and database-fallback registry states
2. Both cases pass and consume `vector_store_ids`
3. Run the three related test files
4. All 539 tests pass

Commands:

```bash
uv run --frozen --extra proxy pytest \
  tests/test_litellm/litellm_core_utils/test_litellm_logging.py \
  tests/test_litellm/integrations/test_anthropic_cache_control_hook.py \
  tests/test_litellm/integrations/vector_store_integrations/test_vector_store_pre_call_hook.py -q

uv run --frozen --extra proxy ruff format --check \
  litellm/litellm_core_utils/litellm_logging.py

uv run --frozen --extra proxy ruff check \
  litellm/litellm_core_utils/litellm_logging.py

uv run --frozen --extra proxy ruff check --config ruff-tests.toml \
  tests/test_litellm/litellm_core_utils/test_litellm_logging.py
```

## Type

Bug Fix

## Caveats (if any)

### Low

- Live Bedrock knowledge-base proof is still pending
- Scope is asynchronous chat-completion prompt processing

## Final Attestation

- [ ] The live customer flow has been verified on the current tip