### PR TITLE
fix: strip extra_headers from image generation JSON body

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -474,8 +474,9 @@ def image_generation(
             or custom_llm_provider == LlmProviders.LITELLM_PROXY.value
             or custom_llm_provider in litellm.openai_compatible_providers
         ):
-            if extra_headers is not None:
-                optional_params["extra_headers"] = extra_headers
+            # extra_headers belongs on the HTTP request, not in the JSON body.
+            # Pop it so it does not leak into optional_params → data → request body.
+            optional_params.pop("extra_headers", None)
             # Forward OpenAI organization if present (set by proxy pre-call utils)
             organization: Final[str | None] = kwargs.get("organization", None)
             model_response = openai_chat_completions.image_generation(

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1469,6 +1469,10 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
     ) -> ImageResponse:
         data = {}
         try:
+            # extra_headers is an HTTP-header concern, not a JSON body field.
+            # Strip it defensively so it never reaches the request body even if a
+            # caller accidentally leaves it in optional_params.
+            optional_params.pop("extra_headers", None)
             data = {"model": model, "prompt": prompt, **optional_params}
             max_retries: Final = data.pop("max_retries", 2)
             if not isinstance(max_retries, int):

--- a/tests/test_image_generation_extra_headers.py
+++ b/tests/test_image_generation_extra_headers.py
@@ -1,0 +1,156 @@
+"""
+Tests for OpenAI image generation extra_headers handling.
+
+Ensures extra_headers are used as HTTP headers only and never leak into the
+JSON request body sent to the upstream API.
+
+Ref: https://github.com/BerriAI/litellm/issues/40628
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestOpenAIImageGenerationExtraHeaders:
+    """Verify extra_headers stays on the HTTP layer, not the JSON body."""
+
+    def test_extra_headers_not_in_request_body(self):
+        """
+        When optional_params contains extra_headers (e.g. from credential config),
+        the OpenAI images.generate() call must NOT receive extra_headers as a
+        JSON body field.
+        """
+        from litellm.llms.openai.openai import OpenAIHandler
+
+        handler = OpenAIHandler(api_key="sk-test", api_base="https://example.com/v1")
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "data": [{"url": "https://example.com/img.png"}]
+        }
+
+        mock_client = MagicMock()
+        mock_client.images.generate.return_value = mock_response
+        mock_client.api_key = "sk-test"
+        mock_client._base_url = MagicMock()
+        mock_client._base_url._uri_reference = "https://example.com/v1/"
+
+        logging_obj = MagicMock()
+
+        optional_params = {
+            "n": 1,
+            "size": "1024x1024",
+            "extra_headers": {"cf-aig-authorization": "Bearer cfut_123"},
+        }
+
+        result = handler.image_generation(
+            model="gpt-image-2",
+            prompt="a red circle",
+            timeout=60,
+            optional_params=optional_params,
+            logging_obj=logging_obj,
+            api_key="sk-test",
+            api_base="https://example.com/v1",
+            model_response=MagicMock(),
+            client=mock_client,
+            aimg_generation=False,
+        )
+
+        # Verify the call was made
+        assert mock_client.images.generate.called
+
+        # Inspect the kwargs passed to images.generate
+        call_kwargs = mock_client.images.generate.call_args
+        # extra_headers should NOT be in the body parameters
+        body_params = call_kwargs.kwargs
+        assert "extra_headers" not in body_params, (
+            "extra_headers leaked into the JSON body params! "
+            f"Got params: {list(body_params.keys())}"
+        )
+
+    def test_extra_headers_passed_as_http_headers(self):
+        """
+        When headers are explicitly provided, they should be passed via
+        extra_headers keyword to the SDK (which sends them as HTTP headers).
+        """
+        from litellm.llms.openai.openai import OpenAIHandler
+
+        handler = OpenAIHandler(api_key="sk-test", api_base="https://example.com/v1")
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "data": [{"url": "https://example.com/img.png"}]
+        }
+
+        mock_client = MagicMock()
+        mock_client.images.generate.return_value = mock_response
+        mock_client.api_key = "sk-test"
+        mock_client._base_url = MagicMock()
+        mock_client._base_url._uri_reference = "https://example.com/v1/"
+
+        logging_obj = MagicMock()
+
+        optional_params = {"n": 1, "size": "1024x1024"}
+        headers = {"cf-aig-authorization": "Bearer cfut_123"}
+
+        result = handler.image_generation(
+            model="gpt-image-2",
+            prompt="a red circle",
+            timeout=60,
+            optional_params=optional_params,
+            logging_obj=logging_obj,
+            api_key="sk-test",
+            api_base="https://example.com/v1",
+            model_response=MagicMock(),
+            client=mock_client,
+            aimg_generation=False,
+            headers=headers,
+        )
+
+        # Verify the call was made
+        assert mock_client.images.generate.called
+
+        call_kwargs = mock_client.images.generate.call_args.kwargs
+        # extra_headers should be passed as the SDK keyword for HTTP headers
+        assert "extra_headers" in call_kwargs, (
+            "headers should be passed as extra_headers to the SDK"
+        )
+        assert call_kwargs["extra_headers"]["cf-aig-authorization"] == "Bearer cfut_123"
+        # Body params should NOT contain extra_headers
+        body_keys = [k for k in call_kwargs if k != "extra_headers"]
+        assert "extra_headers" not in body_keys
+
+    def test_image_generation_entry_strips_extra_headers_from_optional_params(self):
+        """
+        The image_generation() entry point in litellm/images/main.py should
+        strip extra_headers from optional_params before passing to OpenAI handler.
+        """
+        # Mock the components to test the flow
+        with patch("litellm.images.main.get_llm_provider", return_value=("gpt-image-2", "openai", "sk-test", "https://api.openai.com/v1")):
+            with patch("litellm.images.main.get_optional_params_image_gen") as mock_get_params:
+                with patch("litellm.images.main.openai_chat_completions") as mock_openai:
+                    mock_get_params.return_value = {
+                        "n": 1,
+                        "extra_headers": {"cf-aig-authorization": "Bearer cfut_123"},
+                    }
+                    mock_openai.image_generation.return_value = MagicMock()
+
+                    import litellm.images.main as img_main
+
+                    img_main.image_generation(
+                        prompt="a red circle",
+                        model="gpt-image-2",
+                        n=1,
+                        extra_headers={"cf-aig-authorization": "Bearer cfut_123"},
+                    )
+
+                    # Verify the OpenAI handler was called
+                    assert mock_openai.image_generation.called
+                    call_kwargs = mock_openai.image_generation.call_args.kwargs
+                    optional_params = call_kwargs.get("optional_params", {})
+                    # extra_headers should have been stripped
+                    assert "extra_headers" not in optional_params, (
+                        f"extra_headers leaked into optional_params: {optional_params}"
+                    )


### PR DESCRIPTION
Fixes #40628

## Changes
- `litellm/images/main.py`: pop `extra_headers` from `optional_params` for OpenAI and compatible providers instead of adding it (it was being merged into the JSON body)
- `litellm/llms/openai/openai.py`: defensive pop of `extra_headers` from `optional_params` before constructing the request body dict
- Added regression test `tests/test_image_generation_extra_headers.py` ensuring `extra_headers` never leaks into the JSON body

## Root Cause
When a model/credential config includes `extra_headers` (e.g. for Cloudflare AI Gateway auth), the proxy's `add_litellm_data_to_request` adds it to the request data dict. The `image_generation` entry point then merged it into `optional_params`, which got spread into the JSON body sent to `POST /v1/images/generations`. OpenAI's API rejected it as an unknown parameter.

## Testing
- Added unit tests verifying `extra_headers` is not present in the JSON body params
- Added test verifying `extra_headers` is still passed correctly as HTTP headers via the SDK's `extra_headers` keyword