### PR TITLE
fix(zai): pass thinking and reasoning_effort via extra_body

### DIFF
--- a/litellm/llms/zai/chat/transformation.py
+++ b/litellm/llms/zai/chat/transformation.py
@@ -1,3 +1,4 @@
+from types import MappingProxyType
 from typing import Final
 
 from litellm.secret_managers.main import get_secret_str
@@ -6,6 +7,7 @@ from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
 ZAI_API_BASE: Final = "https://api.z.ai/api/paas/v4"
+ZAI_REASONING_PARAMS: Final = frozenset(("thinking", "reasoning_effort"))
 
 
 class ZAIChatConfig(OpenAIGPTConfig):
@@ -49,8 +51,31 @@ class ZAIChatConfig(OpenAIGPTConfig):
 
         try:
             if litellm.supports_reasoning(model=model, custom_llm_provider=self.custom_llm_provider):
-                base_params.append("thinking")
+                return [*base_params, *sorted(ZAI_REASONING_PARAMS)]  # mutable-ok: base class returns a list
         except Exception:
             pass
 
         return base_params
+
+    def _map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        supported_openai_params: Final = frozenset(self.get_supported_openai_params(model))
+        reasoning_params: Final = MappingProxyType(
+            {k: v for k, v in non_default_params.items() if k in ZAI_REASONING_PARAMS and k in supported_openai_params}
+        )
+        optional_params.update(
+            (k, v)
+            for k, v in non_default_params.items()
+            if k in supported_openai_params and k not in ZAI_REASONING_PARAMS
+        )
+        if reasoning_params:
+            optional_params["extra_body"] = {  # mutable-ok: the OpenAI SDK json-encodes extra_body from a plain dict
+                **(optional_params.get("extra_body") or MappingProxyType({})),
+                **reasoning_params,
+            }
+        return optional_params

--- a/litellm/llms/zai/chat/transformation.py
+++ b/litellm/llms/zai/chat/transformation.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Final
 
@@ -59,11 +60,11 @@ class ZAIChatConfig(OpenAIGPTConfig):
 
     def _map_openai_params(
         self,
-        non_default_params: dict,
-        optional_params: dict,
+        non_default_params: dict[str, object],
+        optional_params: dict[str, object],
         model: str,
         drop_params: bool,
-    ) -> dict:
+    ) -> dict[str, object]:
         supported_openai_params: Final = frozenset(self.get_supported_openai_params(model))
         reasoning_params: Final = MappingProxyType(
             {k: v for k, v in non_default_params.items() if k in ZAI_REASONING_PARAMS and k in supported_openai_params}
@@ -77,8 +78,10 @@ class ZAIChatConfig(OpenAIGPTConfig):
         )
         if not reasoning_params:
             return {**optional_params, **passthrough_params}  # mutable-ok: base class returns a dict
+        existing: Final = optional_params.get("extra_body")
+        existing_body: Final = existing if isinstance(existing, Mapping) else MappingProxyType({})
         extra_body: Final = {  # mutable-ok: the OpenAI SDK json-encodes extra_body from a plain dict
-            **(optional_params.get("extra_body") or MappingProxyType({})),
+            **existing_body,
             **reasoning_params,
         }
         return {  # mutable-ok: base class returns a dict

--- a/litellm/llms/zai/chat/transformation.py
+++ b/litellm/llms/zai/chat/transformation.py
@@ -68,14 +68,21 @@ class ZAIChatConfig(OpenAIGPTConfig):
         reasoning_params: Final = MappingProxyType(
             {k: v for k, v in non_default_params.items() if k in ZAI_REASONING_PARAMS and k in supported_openai_params}
         )
-        optional_params.update(
-            (k, v)
-            for k, v in non_default_params.items()
-            if k in supported_openai_params and k not in ZAI_REASONING_PARAMS
-        )
-        if reasoning_params:
-            optional_params["extra_body"] = {  # mutable-ok: the OpenAI SDK json-encodes extra_body from a plain dict
-                **(optional_params.get("extra_body") or MappingProxyType({})),
-                **reasoning_params,
+        passthrough_params: Final = MappingProxyType(
+            {
+                k: v
+                for k, v in non_default_params.items()
+                if k in supported_openai_params and k not in ZAI_REASONING_PARAMS
             }
-        return optional_params
+        )
+        if not reasoning_params:
+            return {**optional_params, **passthrough_params}  # mutable-ok: base class returns a dict
+        extra_body: Final = {  # mutable-ok: the OpenAI SDK json-encodes extra_body from a plain dict
+            **(optional_params.get("extra_body") or MappingProxyType({})),
+            **reasoning_params,
+        }
+        return {  # mutable-ok: base class returns a dict
+            **optional_params,
+            **passthrough_params,
+            "extra_body": extra_body,
+        }

--- a/tests/test_litellm/llms/zai/test_zai_provider.py
+++ b/tests/test_litellm/llms/zai/test_zai_provider.py
@@ -2,6 +2,7 @@
 Tests for Z.AI (Zhipu AI) provider - GLM models
 """
 
+import json
 import math
 
 import pytest
@@ -89,9 +90,7 @@ async def test_zai_completion_call(respx_mock, zai_response, monkeypatch):
     monkeypatch.setenv("ZAI_API_KEY", "test-api-key")
     monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
 
-    respx_mock.post("https://api.z.ai/api/paas/v4/chat/completions").respond(
-        json=zai_response
-    )
+    respx_mock.post("https://api.z.ai/api/paas/v4/chat/completions").respond(json=zai_response)
 
     response = await litellm.acompletion(
         model="zai/glm-4.6",
@@ -115,9 +114,7 @@ def test_zai_sync_completion(respx_mock, zai_response, monkeypatch):
     monkeypatch.setenv("ZAI_API_KEY", "test-api-key")
     monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
 
-    respx_mock.post("https://api.z.ai/api/paas/v4/chat/completions").respond(
-        json=zai_response
-    )
+    respx_mock.post("https://api.z.ai/api/paas/v4/chat/completions").respond(json=zai_response)
 
     response = completion(
         model="zai/glm-4.6",
@@ -127,3 +124,104 @@ def test_zai_sync_completion(respx_mock, zai_response, monkeypatch):
 
     assert response.choices[0].message.content == "Hello! How can I help you today?"
     assert response.usage.total_tokens == 25
+
+
+@pytest.fixture
+def zai_thinking_response():
+    return {
+        "id": "chatcmpl-zai-thinking",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "glm-4.7",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+    }
+
+
+def _captured_body(respx_mock) -> dict:
+    assert len(respx_mock.calls) == 1
+    return json.loads(respx_mock.calls[0].request.content.decode("utf-8"))
+
+
+def test_reasoning_params_supported_on_reasoning_models(local_model_cost_map):
+    from litellm.llms.zai.chat.transformation import ZAIChatConfig
+
+    params = ZAIChatConfig().get_supported_openai_params(model="glm-4.7")
+    assert "thinking" in params
+    assert "reasoning_effort" in params
+
+
+def test_reasoning_params_not_supported_without_reasoning_flag(monkeypatch):
+    from litellm.llms.zai.chat.transformation import ZAIChatConfig
+
+    monkeypatch.setattr(litellm, "supports_reasoning", lambda **kwargs: False)
+    params = ZAIChatConfig().get_supported_openai_params(model="glm-4-32b-0414-128k")
+    assert "thinking" not in params
+    assert "reasoning_effort" not in params
+
+
+def test_thinking_and_reasoning_effort_move_into_extra_body(local_model_cost_map):
+    from litellm.llms.zai.chat.transformation import ZAIChatConfig
+
+    result = ZAIChatConfig()._map_openai_params(
+        non_default_params={"max_tokens": 100, "thinking": {"type": "disabled"}, "reasoning_effort": "low"},
+        optional_params={},
+        model="glm-4.7",
+        drop_params=False,
+    )
+    assert result["max_tokens"] == 100
+    assert "thinking" not in result
+    assert "reasoning_effort" not in result
+    assert result["extra_body"] == {"thinking": {"type": "disabled"}, "reasoning_effort": "low"}
+
+
+def test_existing_extra_body_is_kept_and_not_mutated(local_model_cost_map):
+    from litellm.llms.zai.chat.transformation import ZAIChatConfig
+
+    caller_extra_body = {"already_here": True}
+    result = ZAIChatConfig()._map_openai_params(
+        non_default_params={"thinking": {"type": "disabled"}},
+        optional_params={"extra_body": caller_extra_body},
+        model="glm-4.7",
+        drop_params=False,
+    )
+    assert result["extra_body"] == {"already_here": True, "thinking": {"type": "disabled"}}
+    assert caller_extra_body == {"already_here": True}
+
+
+def test_reasoning_params_dropped_for_non_reasoning_model(monkeypatch):
+    from litellm.utils import get_optional_params
+
+    monkeypatch.setattr(litellm, "supports_reasoning", lambda **kwargs: False)
+    result = get_optional_params(
+        model="glm-4-32b-0414-128k",
+        custom_llm_provider="zai",
+        thinking={"type": "disabled"},
+        reasoning_effort="low",
+        drop_params=True,
+    )
+    assert "thinking" not in result
+    assert "reasoning_effort" not in result
+    assert "thinking" not in result.get("extra_body", {})
+    assert "reasoning_effort" not in result.get("extra_body", {})
+
+
+@pytest.mark.asyncio
+async def test_thinking_and_reasoning_effort_reach_http_body(
+    respx_mock, zai_thinking_response, monkeypatch, local_model_cost_map
+):
+    monkeypatch.setenv("ZAI_API_KEY", "test-api-key")
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+    respx_mock.post("https://api.z.ai/api/paas/v4/chat/completions").respond(json=zai_thinking_response)
+
+    await litellm.acompletion(
+        model="zai/glm-4.7",
+        messages=[{"role": "user", "content": "hi"}],
+        thinking={"type": "disabled"},
+        reasoning_effort="low",
+    )
+
+    body = _captured_body(respx_mock)
+    assert body["thinking"] == {"type": "disabled"}
+    assert body["reasoning_effort"] == "low"
+    assert "extra_body" not in body

--- a/tests/test_litellm/llms/zai/test_zai_provider.py
+++ b/tests/test_litellm/llms/zai/test_zai_provider.py
@@ -175,17 +175,25 @@ def test_thinking_and_reasoning_effort_move_into_extra_body(local_model_cost_map
     assert result["extra_body"] == {"thinking": {"type": "disabled"}, "reasoning_effort": "low"}
 
 
-def test_existing_extra_body_is_kept_and_not_mutated(local_model_cost_map):
+def test_caller_optional_params_and_extra_body_are_not_mutated(local_model_cost_map):
     from litellm.llms.zai.chat.transformation import ZAIChatConfig
 
     caller_extra_body = {"already_here": True}
+    caller_optional_params = {"stream": False, "extra_body": caller_extra_body}
     result = ZAIChatConfig()._map_openai_params(
-        non_default_params={"thinking": {"type": "disabled"}},
-        optional_params={"extra_body": caller_extra_body},
+        non_default_params={"max_tokens": 100, "thinking": {"type": "disabled"}},
+        optional_params=caller_optional_params,
         model="glm-4.7",
         drop_params=False,
     )
-    assert result["extra_body"] == {"already_here": True, "thinking": {"type": "disabled"}}
+    assert result == {
+        "stream": False,
+        "max_tokens": 100,
+        "extra_body": {"already_here": True, "thinking": {"type": "disabled"}},
+    }
+    assert result is not caller_optional_params
+    assert caller_optional_params == {"stream": False, "extra_body": {"already_here": True}}
+    assert caller_optional_params["extra_body"] is caller_extra_body
     assert caller_extra_body == {"already_here": True}
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `thinking` on a Z.AI GLM model returns HTTP 500 from the OpenAI SDK
- `reasoning_effort` on Z.AI is rejected as an unsupported parameter
- Callers cannot turn GLM reasoning off, so every request pays for reasoning tokens

How it solves it:

- Z.AI now lists `thinking` and `reasoning_effort` as supported on reasoning models
- Both fields travel inside `extra_body`, which the SDK flattens into the JSON body
- The override returns a new dict, so the caller's `optional_params` and `extra_body` are never mutated

## User Flow

Before: a developer who wants a short GLM answer without reasoning gets a 500 instead of a completion

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "glm-4.7"` and `"thinking": {"type": "disabled"}`
2. The response is HTTP 500 with `"AsyncCompletions.create() got an unexpected keyword argument 'thinking'"`
3. They try `"reasoning_effort": "low"` instead and get HTTP 400 `"zai does not support parameters: ['reasoning_effort']"`
4. They drop both fields, get HTTP 200, and the usage block shows dozens of `reasoning_tokens` they did not want to pay for

After: the same request comes back with a plain answer and no reasoning tokens

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "glm-4.7"` and `"thinking": {"type": "disabled"}`
2. The response is HTTP 200, `reasoning_content` is null and `completion_tokens` is 1
3. `"reasoning_effort": "low"` is accepted with HTTP 200 and forwarded to Z.AI
4. A request that also carries its own `extra_body` keeps those fields and still honors `thinking`

## Relevant issues

Refiled from #40714, which GitHub auto-closed when the litellm_internal_staging branch was deleted on 2026-09-13; that PR holds the earlier Greptile rounds (5/5 at the current tip) and the resolved threads. The branch is unchanged and merges cleanly into main

No existing issue. `ZAIChatConfig` inherits `OpenAIGPTConfig._map_openai_params`, which copies every supported parameter to the top level of the request kwargs. The OpenAI SDK has no `thinking` kwarg, so any GLM request that sets it dies inside `AsyncCompletions.create()` and the proxy answers 500. `reasoning_effort` was missing from the Z.AI supported list entirely, so it was rejected as unsupported, or silently dropped when `drop_params` is on. Both are documented Z.AI request body fields (https://docs.z.ai/api-reference/llm/chat-completion) and belong in `extra_body`

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on `localhost:4103` against the real `api.z.ai` gateway, model `glm-4.7`, started with `python litellm/proxy/proxy_cli.py --config config.yaml --port 4103`

Config:

```yaml
model_list:
  - model_name: glm-4.7
    litellm_params:
      model: zai/glm-4.7
      api_key: os.environ/ZAI_API_KEY
      api_base: os.environ/ZAI_API_BASE
general_settings:
  master_key: sk-REDACTED
```

Every request below is the same shape; only the reasoning fields and the nonce differ:

```bash
curl -s http://localhost:4103/v1/chat/completions \
  -H 'Authorization: Bearer sk-REDACTED' -H 'Content-Type: application/json' \
  -d '{"model":"glm-4.7","messages":[{"role":"user","content":"Reply with exactly the word pong. nonce=..."}],"max_tokens":64, ...}'
```

Output is shown as the message content, `reasoning_content`, and `usage`, plus the HTTP status

### Before (9a715df212)

#### thinking disabled

1. Body adds `"thinking":{"type":"disabled"}`
2. Output:
   ```json
   {"error": {"message": "litellm.InternalServerError: InternalServerError: ZaiException - AsyncCompletions.create() got an unexpected keyword argument 'thinking'. Received Model Group=glm-4.7\nAvailable Model Group Fallbacks=None", "type": "internal_server_error", "param": null, "code": "500"}}
   HTTP 500
   ```

#### reasoning_effort low

1. Body adds `"reasoning_effort":"low"`
2. Output:
   ```json
   {"error": {"message": "litellm.UnsupportedParamsError: zai does not support parameters: ['reasoning_effort'], for model=glm-4.7. To drop these, set `litellm.drop_params=True` or for proxy:\n\n`litellm_settings:\n drop_params: true`\n. \n If you want to use these params dynamically send allowed_openai_params=['reasoning_effort'] in your request.. Received Model Group=glm-4.7\nAvailable Model Group Fallbacks=None", "type": "invalid_request_error", "param": null, "code": "400"}}
   HTTP 400
   ```

#### caller extra_body plus thinking disabled

1. Body adds `"thinking":{"type":"disabled"},"extra_body":{"request_id":"proof-before-3"}`
2. Output:
   ```json
   {"error": {"message": "litellm.InternalServerError: InternalServerError: ZaiException - AsyncCompletions.create() got an unexpected keyword argument 'thinking'. Received Model Group=glm-4.7\nAvailable Model Group Fallbacks=None", "type": "internal_server_error", "param": null, "code": "500"}}
   HTTP 500
   ```

#### control, no reasoning field

1. Body has no `thinking` or `reasoning_effort`
2. Output:
   ```json
   {"content": "pong", "reasoning_content": "\nThe user wants the exact word \"pong\" as a reply. ...", "usage": {"completion_tokens": 89, "prompt_tokens": 17, "total_tokens": 106, "completion_tokens_details": {"reasoning_tokens": 86}, "prompt_tokens_details": {"cached_tokens": 0}}}
   HTTP 200
   ```

### After (ae77461294)

#### thinking disabled

1. Body adds `"thinking":{"type":"disabled"}`
2. Output:
   ```json
   {"content": "pong", "reasoning_content": null, "usage": {"completion_tokens": 1, "prompt_tokens": 18, "total_tokens": 19, "prompt_tokens_details": {"cached_tokens": 0}}}
   HTTP 200
   ```

#### reasoning_effort low

1. Body adds `"reasoning_effort":"low"`
2. Output:
   ```json
   {"content": "pong", "reasoning_content": "\n1.  **Analyze the Request:** The user wants me to reply wit...", "usage": {"completion_tokens": 363, "prompt_tokens": 18, "total_tokens": 381, "completion_tokens_details": {"reasoning_tokens": 360}, "prompt_tokens_details": {"cached_tokens": 0}}}
   HTTP 200
   ```

#### caller extra_body plus thinking disabled

1. Body adds `"thinking":{"type":"disabled"},"extra_body":{"request_id":"proof-after-ae77461294"}`
2. Output:
   ```json
   {"content": "pong", "reasoning_content": null, "usage": {"completion_tokens": 1, "prompt_tokens": 18, "total_tokens": 19, "prompt_tokens_details": {"cached_tokens": 0}}}
   HTTP 200
   ```

#### control, no reasoning field

1. Body has no `thinking` or `reasoning_effort`
2. Output:
   ```json
   {"content": "pong", "reasoning_content": "\n1.  **Analyze the Request:**\n    *   The user asks for a re...", "usage": {"completion_tokens": 336, "prompt_tokens": 18, "total_tokens": 354, "completion_tokens_details": {"reasoning_tokens": 333}, "prompt_tokens_details": {"cached_tokens": 0}}}
   HTTP 200
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- `reasoning_effort` is forwarded but `glm-4.7` still reasons; Z.AI documents it for GLM-5.2 and newer
- Both fields stay gated on `supports_reasoning`; the `zai/glm-4.5*` registry rows lack that flag and are a separate registry follow-up
- Tests for the mapping run against the real `get_optional_params` path and a respx-captured HTTP body; the four new regressions fail when the production change is reverted

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
