### PR TITLE
fix(auth): check the key allowlist on team alias targets

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -4015,7 +4015,7 @@ def _check_model_access_helper(
     if SpecialModelNames.all_proxy_models.value in filtered_models:
         all_model_access = True
 
-    if effective_model is not None and effective_model not in filtered_models and all_model_access is False:
+    if effective_model not in filtered_models and all_model_access is False:
         return False
     return True
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -10,12 +10,13 @@ Run checks for:
 """
 
 import asyncio
+import functools
 import math
 import re
 import time
 from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Final, Literal, Optional, Protocol, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Optional, Protocol, cast
 
 from fastapi import HTTPException, Request, status
 from pydantic import BaseModel
@@ -120,6 +121,7 @@ from litellm.repositories.table_repositories import (
 from litellm.repositories.team_repository import TeamRepository
 from litellm.repositories.user_repository import UserRepository
 from litellm.router import Router
+from litellm.secret_managers.main import get_secret_bool
 from litellm.types.proxy.model_access_group_budget import ModelAccessGroupBudget
 from litellm.utils import get_utc_datetime
 
@@ -3930,6 +3932,41 @@ def _resolve_all_team_model_sentinel_for_auth_check(
     return list(dict.fromkeys(non_sentinel_models + proxy_models))
 
 
+TeamAliasReason = Literal["not_alias", "applied", "deleted_target", "sibling_bypassed", "sibling_warned"]
+
+
+class TeamAliasResolution(NamedTuple):
+    model: str
+    reason: TeamAliasReason
+    target: str | None
+
+
+@functools.cache
+def stale_team_alias_bypass_enabled() -> bool:
+    return get_secret_bool("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", False) is True
+
+
+def resolve_team_model_alias(
+    model: str,
+    team_model_aliases: Mapping[str, str] | None,
+    team_id: str | None,
+    llm_router: Router | None,
+    stale_alias_bypass: bool,
+) -> TeamAliasResolution:
+    target: Final = team_model_aliases.get(model) if team_model_aliases else None
+    if target is None:
+        return TeamAliasResolution(model=model, reason="not_alias", target=None)
+    if llm_router is None or not target.startswith(f"model_name_{team_id}_"):
+        return TeamAliasResolution(model=target, reason="applied", target=target)
+    if target not in llm_router.model_name_to_deployment_indices:
+        return TeamAliasResolution(model=model, reason="deleted_target", target=target)
+    if (team_id, model) not in llm_router.team_model_to_deployment_indices:
+        return TeamAliasResolution(model=target, reason="applied", target=target)
+    if stale_alias_bypass:
+        return TeamAliasResolution(model=model, reason="sibling_bypassed", target=target)
+    return TeamAliasResolution(model=target, reason="sibling_warned", target=target)
+
+
 def _check_model_access_helper(
     model: str,
     llm_router: Router | None,
@@ -3940,8 +3977,13 @@ def _check_model_access_helper(
     ## check if model in allowed model names
     from collections import defaultdict
 
-    team_alias_target: Final = team_model_aliases.get(model) if team_model_aliases else None
-    effective_model: Final = team_alias_target if team_alias_target is not None else model
+    effective_model: Final = resolve_team_model_alias(
+        model=model,
+        team_model_aliases=team_model_aliases,
+        team_id=team_id,
+        llm_router=llm_router,
+        stale_alias_bypass=stale_team_alias_bypass_enabled(),
+    ).model
 
     access_groups: dict[str, list[str]] = defaultdict(list)
 
@@ -4018,8 +4060,13 @@ def _can_object_call_model(
             )
         return True
 
-    team_alias_target: Final = team_model_aliases.get(model) if team_model_aliases else None
-    resolved_model: Final = team_alias_target if team_alias_target is not None else model
+    resolved_model: Final = resolve_team_model_alias(
+        model=model,
+        team_model_aliases=team_model_aliases,
+        team_id=team_id,
+        llm_router=llm_router,
+        stale_alias_bypass=stale_team_alias_bypass_enabled(),
+    ).model
     potential_models: Final = [resolved_model]
     if resolved_model in litellm.model_alias_map:
         potential_models.append(litellm.model_alias_map[resolved_model])

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -3940,10 +3940,13 @@ def _check_model_access_helper(
     ## check if model in allowed model names
     from collections import defaultdict
 
+    team_alias_target: Final = team_model_aliases.get(model) if team_model_aliases else None
+    effective_model: Final = team_alias_target if team_alias_target is not None else model
+
     access_groups: dict[str, list[str]] = defaultdict(list)
 
     if llm_router:
-        access_groups = llm_router.get_model_access_groups(model_name=model, team_id=team_id)
+        access_groups = llm_router.get_model_access_groups(model_name=effective_model, team_id=team_id)
 
     models = _resolve_all_team_model_sentinel_for_auth_check(
         models=models,
@@ -3959,16 +3962,7 @@ def _check_model_access_helper(
     # Filter out models that are access_groups
     filtered_models: Final = [m for m in models if m not in access_groups]
 
-    team_alias_target: Final = team_model_aliases.get(model) if team_model_aliases else None
-    if team_alias_target is not None and _check_model_access_helper(
-        model=team_alias_target,
-        llm_router=llm_router,
-        models=models,
-        team_id=team_id,
-    ):
-        return True
-
-    if _model_matches_any_wildcard_pattern_in_list(model=model, allowed_model_list=filtered_models):
+    if _model_matches_any_wildcard_pattern_in_list(model=effective_model, allowed_model_list=filtered_models):
         return True
 
     all_model_access: bool = False
@@ -3979,7 +3973,7 @@ def _check_model_access_helper(
     if SpecialModelNames.all_proxy_models.value in filtered_models:
         all_model_access = True
 
-    if model is not None and model not in filtered_models and all_model_access is False:
+    if effective_model is not None and effective_model not in filtered_models and all_model_access is False:
         return False
     return True
 
@@ -4024,11 +4018,13 @@ def _can_object_call_model(
             )
         return True
 
-    potential_models: Final = [model]
-    if model in litellm.model_alias_map:
-        potential_models.append(litellm.model_alias_map[model])
-    elif llm_router and model in llm_router.model_group_alias:
-        _model: Final = llm_router._get_model_from_alias(model)
+    team_alias_target: Final = team_model_aliases.get(model) if team_model_aliases else None
+    resolved_model: Final = team_alias_target if team_alias_target is not None else model
+    potential_models: Final = [resolved_model]
+    if resolved_model in litellm.model_alias_map:
+        potential_models.append(litellm.model_alias_map[resolved_model])
+    elif llm_router and resolved_model in llm_router.model_group_alias:
+        _model: Final = llm_router._get_model_from_alias(resolved_model)
         if _model:
             potential_models.append(_model)
 
@@ -4038,7 +4034,6 @@ def _can_object_call_model(
             model=m,
             llm_router=llm_router,
             models=models,
-            team_model_aliases=team_model_aliases,
             team_id=team_id,
         ):
             return True

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -3959,7 +3959,13 @@ def _check_model_access_helper(
     # Filter out models that are access_groups
     filtered_models: Final = [m for m in models if m not in access_groups]
 
-    if _model_in_team_aliases(model=model, team_model_aliases=team_model_aliases):
+    team_alias_target: Final = team_model_aliases.get(model) if team_model_aliases else None
+    if team_alias_target is not None and _check_model_access_helper(
+        model=team_alias_target,
+        llm_router=llm_router,
+        models=models,
+        team_id=team_id,
+    ):
         return True
 
     if _model_matches_any_wildcard_pattern_in_list(model=model, allowed_model_list=filtered_models):
@@ -4043,24 +4049,6 @@ def _can_object_call_model(
         param="model",
         code=status.HTTP_403_FORBIDDEN,
     )
-
-
-def _model_in_team_aliases(model: str, team_model_aliases: dict[str, str] | None = None) -> bool:
-    """
-    Returns True if `model` being accessed is an alias of a team model
-
-    - `model=gpt-4o`
-    - `team_model_aliases={"gpt-4o": "gpt-4o-team-1"}`
-        - returns True
-
-    - `model=gp-4o`
-    - `team_model_aliases={"o-3": "o3-preview"}`
-        - returns False
-    """
-    if team_model_aliases:
-        if model in team_model_aliases:
-            return True
-    return False
 
 
 def _resolve_key_models_for_auth_check(valid_token: UserAPIKeyAuth) -> list[str]:

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -151,7 +151,6 @@ def _sanitize_for_log(value: object) -> str:
 
 
 from litellm.router import Router
-from litellm.secret_managers.main import get_secret_bool
 from litellm.types.llms.anthropic import ANTHROPIC_API_HEADERS
 from litellm.types.services import ServiceTypes
 from litellm.types.utils import (
@@ -167,9 +166,6 @@ service_logger_obj: Final = ServiceLogging()  # used for tracking latency on OTE
 # Bounded dedup for stale-alias warnings (FIFO eviction when over cap).
 _MAX_STALE_ALIAS_WARNING_KEYS: Final = 10_000
 _STALE_TEAM_ALIAS_WARNING_KEYS: Final[OrderedDict[str, None]] = OrderedDict()
-# Cache the stale alias bypass flag at module load to avoid hot-path secret lookups
-_ENABLE_TEAM_STALE_ALIAS_BYPASS: bool | None = None
-_TEAM_MODEL_ALIASES: Final = TypeAdapter(dict[str, str] | None)
 
 
 if TYPE_CHECKING:
@@ -2510,22 +2506,19 @@ def _update_model_if_team_alias_exists(
     exist (e.g. a gateway-level model group shared with the team).
     """
     _model: Final = data.get("model")
-    team_model_aliases: Final = _TEAM_MODEL_ALIASES.validate_python(user_api_key_dict.team_model_aliases)
-    if not isinstance(_model, str) or not team_model_aliases or _model not in team_model_aliases:
+    team_model_aliases: Final = user_api_key_dict.team_model_aliases
+    if not isinstance(_model, str) or not isinstance(team_model_aliases, dict) or _model not in team_model_aliases:
         return
 
-    from litellm.proxy.auth.auth_checks import resolve_team_model_alias
+    from litellm.proxy.auth.auth_checks import resolve_team_model_alias, stale_team_alias_bypass_enabled
     from litellm.proxy.proxy_server import llm_router
 
-    global _ENABLE_TEAM_STALE_ALIAS_BYPASS
-    if _ENABLE_TEAM_STALE_ALIAS_BYPASS is None:
-        _ENABLE_TEAM_STALE_ALIAS_BYPASS = get_secret_bool("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", False)
     resolution: Final = resolve_team_model_alias(
         model=_model,
         team_model_aliases=team_model_aliases,
         team_id=user_api_key_dict.team_id,
         llm_router=llm_router,
-        stale_alias_bypass=_ENABLE_TEAM_STALE_ALIAS_BYPASS is True,
+        stale_alias_bypass=stale_team_alias_bypass_enabled(),
     )
     if resolution.reason == "deleted_target":
         _warn_stale_team_alias_once(

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -169,6 +169,7 @@ _MAX_STALE_ALIAS_WARNING_KEYS: Final = 10_000
 _STALE_TEAM_ALIAS_WARNING_KEYS: Final[OrderedDict[str, None]] = OrderedDict()
 # Cache the stale alias bypass flag at module load to avoid hot-path secret lookups
 _ENABLE_TEAM_STALE_ALIAS_BYPASS: bool | None = None
+_TEAM_MODEL_ALIASES: Final = TypeAdapter(dict[str, str] | None)
 
 
 if TYPE_CHECKING:
@@ -2509,55 +2510,48 @@ def _update_model_if_team_alias_exists(
     exist (e.g. a gateway-level model group shared with the team).
     """
     _model: Final = data.get("model")
-    if not _model or not user_api_key_dict.team_model_aliases or _model not in user_api_key_dict.team_model_aliases:
+    team_model_aliases: Final = _TEAM_MODEL_ALIASES.validate_python(user_api_key_dict.team_model_aliases)
+    if not isinstance(_model, str) or not team_model_aliases or _model not in team_model_aliases:
         return
 
+    from litellm.proxy.auth.auth_checks import resolve_team_model_alias
     from litellm.proxy.proxy_server import llm_router
 
-    # Skip alias rewrite if this model resolves to team-specific deployments
-    # (team models use team_public_model_name, not model_aliases)
-    aliased_target: Final = user_api_key_dict.team_model_aliases[_model]
-
-    # Optional bypass for stale aliases from pre-PR deployments:
-    # only enabled via feature flag to preserve backwards compatibility.
-    # Cached at module level to avoid hot-path secret lookups on every request.
     global _ENABLE_TEAM_STALE_ALIAS_BYPASS
     if _ENABLE_TEAM_STALE_ALIAS_BYPASS is None:
         _ENABLE_TEAM_STALE_ALIAS_BYPASS = get_secret_bool("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", False)
-    enable_stale_alias_bypass: Final = _ENABLE_TEAM_STALE_ALIAS_BYPASS
-    # Check if the alias points to a team-scoped UUID name
-    # (format: "model_name_{team_id}_{uuid}")
-    is_stale_team_alias: Final = aliased_target.startswith(f"model_name_{user_api_key_dict.team_id}_")
-    if is_stale_team_alias and llm_router:
-        if aliased_target not in llm_router.model_name_to_deployment_indices:
-            _warn_stale_team_alias_once(
-                f"deleted:{user_api_key_dict.team_id}:{_model}:{aliased_target}",
-                "Team model alias for model='%s', team_id='%s' targets '%s', which has no live "
-                "deployment. Routing with the requested model name instead; remove the stale "
-                "entry from the team's model_aliases to silence this warning.",
-                _sanitize_for_log(_model),
-                _sanitize_for_log(user_api_key_dict.team_id),
-                _sanitize_for_log(aliased_target),
-            )
-            return
-        # This is a stale alias from pre-PR deployments.
-        # Check if current team deployments exist for the public name.
-        key: Final = (user_api_key_dict.team_id, _model)
-        if key in llm_router.team_model_to_deployment_indices:
-            if enable_stale_alias_bypass:
-                # Team deployments exist; skip stale alias
-                return
-            _warn_stale_team_alias_once(
-                f"{user_api_key_dict.team_id}:{_model}:{aliased_target}",
-                "Stale team model alias detected for model='%s', team_id='%s'. "
-                "New sibling deployments may be unreachable. "
-                "Set LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS=true to enable "
-                "team-scoped sibling routing.",
-                _sanitize_for_log(_model),
-                _sanitize_for_log(user_api_key_dict.team_id),
-            )
+    resolution: Final = resolve_team_model_alias(
+        model=_model,
+        team_model_aliases=team_model_aliases,
+        team_id=user_api_key_dict.team_id,
+        llm_router=llm_router,
+        stale_alias_bypass=_ENABLE_TEAM_STALE_ALIAS_BYPASS is True,
+    )
+    if resolution.reason == "deleted_target":
+        _warn_stale_team_alias_once(
+            f"deleted:{user_api_key_dict.team_id}:{_model}:{resolution.target}",
+            "Team model alias for model='%s', team_id='%s' targets '%s', which has no live "
+            "deployment. Routing with the requested model name instead; remove the stale "
+            "entry from the team's model_aliases to silence this warning.",
+            _sanitize_for_log(_model),
+            _sanitize_for_log(user_api_key_dict.team_id),
+            _sanitize_for_log(resolution.target),
+        )
+        return
+    if resolution.reason == "sibling_bypassed":
+        return
+    if resolution.reason == "sibling_warned":
+        _warn_stale_team_alias_once(
+            f"{user_api_key_dict.team_id}:{_model}:{resolution.target}",
+            "Stale team model alias detected for model='%s', team_id='%s'. "
+            "New sibling deployments may be unreachable. "
+            "Set LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS=true to enable "
+            "team-scoped sibling routing.",
+            _sanitize_for_log(_model),
+            _sanitize_for_log(user_api_key_dict.team_id),
+        )
 
-    data["model"] = aliased_target
+    data["model"] = resolution.model
 
 
 def _update_model_if_key_alias_exists(

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -2230,11 +2230,10 @@ def test_update_model_if_team_alias_exists(data, user_api_key_dict, expected_mod
 
 def test_team_alias_stale_bypass_disabled_by_default(monkeypatch):
     monkeypatch.delenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", raising=False)
-    import litellm.proxy.litellm_pre_call_utils as pre_call_utils
+    from litellm.proxy.auth.auth_checks import stale_team_alias_bypass_enabled
     from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
 
-    # Reset module-level cache to ensure test isolation
-    pre_call_utils._ENABLE_TEAM_STALE_ALIAS_BYPASS = None
+    stale_team_alias_bypass_enabled.cache_clear()
 
     class _MockRouter:
         model_name_to_deployment_indices = {"model_name_team-1_legacy-uuid": [0]}
@@ -2256,11 +2255,8 @@ def test_team_alias_stale_bypass_disabled_by_default(monkeypatch):
 
 
 def test_team_alias_stale_bypass_enabled_by_flag(monkeypatch):
-    import litellm.proxy.litellm_pre_call_utils as pre_call_utils
+    from litellm.proxy.auth.auth_checks import stale_team_alias_bypass_enabled
     from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
-
-    # Reset module-level cache to ensure test isolation
-    pre_call_utils._ENABLE_TEAM_STALE_ALIAS_BYPASS = None
 
     class _MockRouter:
         model_name_to_deployment_indices = {"model_name_team-1_legacy-uuid": [0]}
@@ -2273,6 +2269,7 @@ def test_team_alias_stale_bypass_enabled_by_flag(monkeypatch):
         team_model_aliases={"gpt-4o": "model_name_team-1_legacy-uuid"},
     )
     monkeypatch.setenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", "true")
+    stale_team_alias_bypass_enabled.cache_clear()
 
     with patch("litellm.proxy.proxy_server.llm_router", _MockRouter()):
         _update_model_if_team_alias_exists(

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -588,6 +588,119 @@ def test_can_object_call_model_team_alias_takes_precedence_over_router_alias():
     )
 
 
+def _router_with_team_deployment(public_name: str, team_id: str, internal_name: str) -> "Router":
+    from litellm import Router
+
+    return Router(
+        model_list=[
+            {"model_name": public_name, "litellm_params": {"model": "gpt-4o", "api_key": "test-api-key"}},
+            {
+                "model_name": internal_name,
+                "litellm_params": {"model": "gpt-4o", "api_key": "test-api-key"},
+                "model_info": {"team_id": team_id, "team_public_model_name": public_name},
+            },
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    ("aliases", "bypass", "live_target", "sibling", "expected_model", "expected_reason"),
+    [
+        (None, False, True, False, "gpt-4o-group", "not_alias"),
+        ({"gpt-4o-group": "openai/gpt-4.1-mini"}, False, True, False, "openai/gpt-4.1-mini", "applied"),
+        ({"gpt-4o-group": "model_name_team-1_x"}, False, False, False, "gpt-4o-group", "deleted_target"),
+        ({"gpt-4o-group": "model_name_team-1_x"}, False, True, False, "model_name_team-1_x", "applied"),
+        ({"gpt-4o-group": "model_name_team-1_x"}, True, True, True, "gpt-4o-group", "sibling_bypassed"),
+        ({"gpt-4o-group": "model_name_team-1_x"}, False, True, True, "model_name_team-1_x", "sibling_warned"),
+    ],
+)
+def test_resolve_team_model_alias_follows_routing(
+    aliases, bypass, live_target, sibling, expected_model, expected_reason
+):
+    """The resolver returns the model name the request will be routed with."""
+    from litellm.proxy.auth.auth_checks import resolve_team_model_alias
+
+    class _Router:
+        model_name_to_deployment_indices = {"model_name_team-1_x": [0]} if live_target else {}
+        team_model_to_deployment_indices = {("team-1", "gpt-4o-group"): [1]} if sibling else {}
+
+    resolution: Final = resolve_team_model_alias(
+        model="gpt-4o-group",
+        team_model_aliases=aliases,
+        team_id="team-1",
+        llm_router=_Router(),  # pyright: ignore[reportArgumentType]  # only the two index maps are read
+        stale_alias_bypass=bypass,
+    )
+
+    assert (resolution.model, resolution.reason) == (expected_model, expected_reason)
+
+
+def test_can_object_call_model_deleted_team_alias_target_checks_requested_name(monkeypatch):
+    """An alias whose team-scoped target has no deployment is authorized as the requested name."""
+    from litellm.proxy.auth import auth_checks
+
+    monkeypatch.setattr(auth_checks, "stale_team_alias_bypass_enabled", lambda: False)
+    llm_router: Final = _router_with_team_deployment("gpt-4o-group", "team-1", "model_name_team-1_live")
+    aliases: Final = {"gpt-4o-group": "model_name_team-1_deadbeef"}
+
+    with pytest.raises(ProxyException) as exc_info:
+        _can_object_call_model(
+            model="gpt-4o-group",
+            llm_router=llm_router,
+            models=["model_name_team-1_deadbeef"],
+            team_model_aliases=aliases,
+            team_id="team-1",
+            object_type="key",
+        )
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+    assert _can_object_call_model(
+        model="gpt-4o-group",
+        llm_router=llm_router,
+        models=["gpt-4o-group"],
+        team_model_aliases=aliases,
+        team_id="team-1",
+        object_type="key",
+    )
+
+
+def test_can_object_call_model_bypassed_stale_alias_checks_requested_name(monkeypatch):
+    """With the stale alias bypass on and a team deployment for the name, the requested name is checked."""
+    from litellm.proxy.auth import auth_checks
+
+    monkeypatch.setattr(auth_checks, "stale_team_alias_bypass_enabled", lambda: True)
+    llm_router: Final = _router_with_team_deployment("gpt-4o-group", "team-1", "model_name_team-1_live")
+    aliases: Final = {"gpt-4o-group": "model_name_team-1_live"}
+
+    with pytest.raises(ProxyException) as exc_info:
+        _can_object_call_model(
+            model="gpt-4o-group",
+            llm_router=llm_router,
+            models=["model_name_team-1_live"],
+            team_model_aliases=aliases,
+            team_id="team-1",
+            object_type="key",
+        )
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+    assert _can_object_call_model(
+        model="gpt-4o-group",
+        llm_router=llm_router,
+        models=["gpt-4o-group"],
+        team_model_aliases=aliases,
+        team_id="team-1",
+        object_type="key",
+    )
+
+    monkeypatch.setattr(auth_checks, "stale_team_alias_bypass_enabled", lambda: False)
+    assert _can_object_call_model(
+        model="gpt-4o-group",
+        llm_router=llm_router,
+        models=["model_name_team-1_live"],
+        team_model_aliases=aliases,
+        team_id="team-1",
+        object_type="key",
+    )
+
+
 def test_resolve_key_models_teamless_all_team_models_returns_empty():
     """_resolve_key_models_for_auth_check must return [] for a teamless key
     with all-team-models, making it equivalent to an unscoped key (unrestricted

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -637,9 +637,10 @@ def test_resolve_team_model_alias_follows_routing(
 
 def test_can_object_call_model_deleted_team_alias_target_checks_requested_name(monkeypatch):
     """An alias whose team-scoped target has no deployment is authorized as the requested name."""
-    from litellm.proxy.auth import auth_checks
+    from litellm.proxy.auth.auth_checks import stale_team_alias_bypass_enabled
 
-    monkeypatch.setattr(auth_checks, "stale_team_alias_bypass_enabled", lambda: False)
+    monkeypatch.delenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", raising=False)
+    stale_team_alias_bypass_enabled.cache_clear()
     llm_router: Final = _router_with_team_deployment("gpt-4o-group", "team-1", "model_name_team-1_live")
     aliases: Final = {"gpt-4o-group": "model_name_team-1_deadbeef"}
 
@@ -665,9 +666,10 @@ def test_can_object_call_model_deleted_team_alias_target_checks_requested_name(m
 
 def test_can_object_call_model_bypassed_stale_alias_checks_requested_name(monkeypatch):
     """With the stale alias bypass on and a team deployment for the name, the requested name is checked."""
-    from litellm.proxy.auth import auth_checks
+    from litellm.proxy.auth.auth_checks import stale_team_alias_bypass_enabled
 
-    monkeypatch.setattr(auth_checks, "stale_team_alias_bypass_enabled", lambda: True)
+    monkeypatch.setenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", "true")
+    stale_team_alias_bypass_enabled.cache_clear()
     llm_router: Final = _router_with_team_deployment("gpt-4o-group", "team-1", "model_name_team-1_live")
     aliases: Final = {"gpt-4o-group": "model_name_team-1_live"}
 
@@ -690,7 +692,8 @@ def test_can_object_call_model_bypassed_stale_alias_checks_requested_name(monkey
         object_type="key",
     )
 
-    monkeypatch.setattr(auth_checks, "stale_team_alias_bypass_enabled", lambda: False)
+    monkeypatch.setenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", "false")
+    stale_team_alias_bypass_enabled.cache_clear()
     assert _can_object_call_model(
         model="gpt-4o-group",
         llm_router=llm_router,

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -519,6 +519,75 @@ def test_check_model_access_helper_self_referential_alias_terminates():
     )
 
 
+def _router_with_group_alias(alias: str, target: str) -> "Router":
+    from litellm import Router
+
+    return Router(
+        model_list=[{"model_name": target, "litellm_params": {"model": "gpt-4o", "api_key": "test-api-key"}}],
+        model_group_alias={alias: {"model": target, "hidden": False}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_team_alias_name_in_key_models_is_not_enough():
+    """A key that lists the alias name but not its target is denied."""
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    for models in (["smart"], ["sm*"]):
+        valid_token: Final = _aliased_key(models=models)
+        with pytest.raises(ProxyException) as exc_info:
+            await can_key_call_model(model="smart", llm_model_list=None, valid_token=valid_token, llm_router=None)
+        assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+        assert "Tried to access smart" in exc_info.value.message
+
+
+def test_can_object_call_model_team_alias_target_expands_router_alias():
+    """A team alias whose target is a router alias is allowed when the key lists the underlying model."""
+    llm_router: Final = _router_with_group_alias(alias="router-fast", target="gpt-4o-group")
+
+    assert _can_object_call_model(
+        model="team-fast",
+        llm_router=llm_router,
+        models=["gpt-4o-group"],
+        team_model_aliases={"team-fast": "router-fast"},
+        object_type="key",
+    )
+    with pytest.raises(ProxyException) as exc_info:
+        _can_object_call_model(
+            model="team-fast",
+            llm_router=llm_router,
+            models=["other"],
+            team_model_aliases={"team-fast": "router-fast"},
+            object_type="key",
+        )
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+
+
+def test_can_object_call_model_team_alias_takes_precedence_over_router_alias():
+    """A name that is both a team alias and a router alias is checked against the team alias target only."""
+    llm_router: Final = _router_with_group_alias(alias="fast", target="gpt-4o-group")
+
+    with pytest.raises(ProxyException) as exc_info:
+        _can_object_call_model(
+            model="fast",
+            llm_router=llm_router,
+            models=["gpt-4o-group"],
+            team_model_aliases={"fast": "openai/gpt-4.1-mini"},
+            object_type="key",
+        )
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+    assert _can_object_call_model(
+        model="fast",
+        llm_router=llm_router,
+        models=["openai/gpt-4.1-mini"],
+        team_model_aliases={"fast": "openai/gpt-4.1-mini"},
+        object_type="key",
+    )
+    assert _can_object_call_model(
+        model="fast", llm_router=llm_router, models=["gpt-4o-group"], team_model_aliases=None, object_type="key"
+    )
+
+
 def test_resolve_key_models_teamless_all_team_models_returns_empty():
     """_resolve_key_models_for_auth_check must return [] for a teamless key
     with all-team-models, making it equivalent to an unscoped key (unrestricted

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -403,6 +403,122 @@ async def test_can_key_call_model_all_team_models_no_team_id_is_unrestricted():
     )
 
 
+_TEAM_ALIASES: Final = {
+    "fast": "openai/gpt-4.1-mini",
+    "smart": "openai/gpt-4.1",
+    "vision": "openai/gpt-4o",
+}
+
+
+def _aliased_key(models: list[str]) -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        api_key="sk-key",
+        team_id="team-1",
+        models=models,
+        team_models=["openai/gpt-4.1-mini", "openai/gpt-4.1"],
+        team_model_aliases=_TEAM_ALIASES,
+    )
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_team_alias_target_outside_key_models_denied():
+    """A team alias whose target is not in key.models is denied."""
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    valid_token: Final = _aliased_key(models=["openai/gpt-4.1-mini"])
+
+    for alias in ("smart", "vision"):
+        with pytest.raises(ProxyException) as exc_info:
+            await can_key_call_model(model=alias, llm_model_list=None, valid_token=valid_token, llm_router=None)
+        assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+        assert exc_info.value.code == str(status.HTTP_403_FORBIDDEN)
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_team_alias_target_in_key_models_allowed():
+    """A team alias whose target is in key.models is allowed, and a plain model name still resolves as before."""
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    valid_token: Final = _aliased_key(models=["openai/gpt-4.1-mini"])
+
+    for model in ("fast", "openai/gpt-4.1-mini"):
+        assert await can_key_call_model(model=model, llm_model_list=None, valid_token=valid_token, llm_router=None)
+
+    with pytest.raises(ProxyException) as exc_info:
+        await can_key_call_model(model="openai/gpt-4.1", llm_model_list=None, valid_token=valid_token, llm_router=None)
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_team_alias_unrestricted_key_allowed():
+    """A key with no model restriction, or the all-proxy-models sentinel, can call any team alias."""
+    from litellm.proxy._types import SpecialModelNames
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    for models in ([], [SpecialModelNames.all_proxy_models.value]):
+        valid_token: Final = _aliased_key(models=models)
+        for alias in _TEAM_ALIASES:
+            assert await can_key_call_model(model=alias, llm_model_list=None, valid_token=valid_token, llm_router=None)
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_team_alias_all_team_models_sentinel():
+    """With the all-team-models sentinel the alias target must be in team_models."""
+    from litellm.proxy._types import SpecialModelNames
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    valid_token: Final = _aliased_key(models=[SpecialModelNames.all_team_models.value])
+
+    for alias in ("fast", "smart"):
+        assert await can_key_call_model(model=alias, llm_model_list=None, valid_token=valid_token, llm_router=None)
+
+    with pytest.raises(ProxyException) as exc_info:
+        await can_key_call_model(model="vision", llm_model_list=None, valid_token=valid_token, llm_router=None)
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+
+
+@pytest.mark.asyncio
+async def test_can_team_access_model_team_alias_checks_target():
+    """A team alias is allowed only when its target is in team.models."""
+    from litellm.proxy.auth.auth_checks import can_team_access_model
+
+    team_object: Final = LiteLLM_TeamTable(team_id="team-1", models=["openai/gpt-4.1-mini"])
+
+    assert await can_team_access_model(
+        model="fast", team_object=team_object, llm_router=None, team_model_aliases=_TEAM_ALIASES
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await can_team_access_model(
+            model="smart", team_object=team_object, llm_router=None, team_model_aliases=_TEAM_ALIASES
+        )
+    assert exc_info.value.type == ProxyErrorTypes.team_model_access_denied
+
+
+def test_check_model_access_helper_team_alias_target_matches_wildcard():
+    """A team alias target is matched against wildcard entries in the allowlist."""
+    from litellm.proxy.auth.auth_checks import _check_model_access_helper
+
+    assert _check_model_access_helper(
+        model="fast", llm_router=None, models=["openai/*"], team_model_aliases=_TEAM_ALIASES, team_id="team-1"
+    )
+    assert not _check_model_access_helper(
+        model="fast", llm_router=None, models=["anthropic/*"], team_model_aliases=_TEAM_ALIASES, team_id="team-1"
+    )
+
+
+def test_check_model_access_helper_self_referential_alias_terminates():
+    """An alias that points at its own name is decided by the allowlist alone."""
+    from litellm.proxy.auth.auth_checks import _check_model_access_helper
+
+    self_alias: Final = {"same": "same"}
+
+    assert _check_model_access_helper(model="same", llm_router=None, models=["same"], team_model_aliases=self_alias)
+    assert not _check_model_access_helper(
+        model="same", llm_router=None, models=["other"], team_model_aliases=self_alias
+    )
+
+
 def test_resolve_key_models_teamless_all_team_models_returns_empty():
     """_resolve_key_models_for_auth_check must return [] for a teamless key
     with all-team-models, making it equivalent to an unscoped key (unrestricted

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -6202,11 +6202,11 @@ def test_team_alias_targeting_deleted_team_deployment_keeps_requested_model(monk
     public name resolves at the gateway level. The rewrite must be skipped
     when the alias target has no live deployment.
     """
-    import litellm.proxy.litellm_pre_call_utils as pre_call_utils
+    from litellm.proxy.auth.auth_checks import stale_team_alias_bypass_enabled
     from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
 
     monkeypatch.delenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", raising=False)
-    pre_call_utils._ENABLE_TEAM_STALE_ALIAS_BYPASS = None
+    stale_team_alias_bypass_enabled.cache_clear()
 
     class _MockRouter:
         model_name_to_deployment_indices = {"gpt-4": [0]}
@@ -6226,11 +6226,11 @@ def test_team_alias_targeting_deleted_team_deployment_keeps_requested_model(monk
 
 
 def test_team_alias_targeting_live_team_deployment_still_rewrites(monkeypatch):
-    import litellm.proxy.litellm_pre_call_utils as pre_call_utils
+    from litellm.proxy.auth.auth_checks import stale_team_alias_bypass_enabled
     from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
 
     monkeypatch.delenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", raising=False)
-    pre_call_utils._ENABLE_TEAM_STALE_ALIAS_BYPASS = None
+    stale_team_alias_bypass_enabled.cache_clear()
 
     class _MockRouter:
         model_name_to_deployment_indices = {"model_name_team-1_live-uuid": [0]}
@@ -6261,12 +6261,11 @@ def test_team_alias_targeting_live_team_deployment_still_rewrites(monkeypatch):
 )
 def test_team_alias_rewrite_matches_auth_resolution(monkeypatch, alias_target, live_target, sibling, bypass):
     """Routing rewrites the model to exactly what the auth resolver reports."""
-    import litellm.proxy.litellm_pre_call_utils as pre_call_utils
-    from litellm.proxy.auth.auth_checks import resolve_team_model_alias
+    from litellm.proxy.auth.auth_checks import resolve_team_model_alias, stale_team_alias_bypass_enabled
     from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
 
     monkeypatch.setenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", "true" if bypass else "false")
-    pre_call_utils._ENABLE_TEAM_STALE_ALIAS_BYPASS = None
+    stale_team_alias_bypass_enabled.cache_clear()
 
     class _MockRouter:
         model_name_to_deployment_indices = {alias_target: [0]} if live_target else {}
@@ -6279,8 +6278,13 @@ def test_team_alias_rewrite_matches_auth_resolution(monkeypatch, alias_target, l
     with patch("litellm.proxy.proxy_server.llm_router", _MockRouter()):
         _update_model_if_team_alias_exists(data=test_data, user_api_key_dict=user_api_key_dict)
 
+    assert stale_team_alias_bypass_enabled() is bypass
     expected = resolve_team_model_alias(
-        model="gpt-4", team_model_aliases=aliases, team_id="team-1", llm_router=_MockRouter(), stale_alias_bypass=bypass
+        model="gpt-4",
+        team_model_aliases=aliases,
+        team_id="team-1",
+        llm_router=_MockRouter(),
+        stale_alias_bypass=stale_team_alias_bypass_enabled(),
     )
     assert test_data["model"] == expected.model
 

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -6249,6 +6249,42 @@ def test_team_alias_targeting_live_team_deployment_still_rewrites(monkeypatch):
     assert test_data.get("model") == "model_name_team-1_live-uuid"
 
 
+@pytest.mark.parametrize(
+    ("alias_target", "live_target", "sibling", "bypass"),
+    [
+        ("openai/gpt-4.1-mini", False, False, False),
+        ("model_name_team-1_dead", False, False, False),
+        ("model_name_team-1_live", True, False, False),
+        ("model_name_team-1_live", True, True, True),
+        ("model_name_team-1_live", True, True, False),
+    ],
+)
+def test_team_alias_rewrite_matches_auth_resolution(monkeypatch, alias_target, live_target, sibling, bypass):
+    """Routing rewrites the model to exactly what the auth resolver reports."""
+    import litellm.proxy.litellm_pre_call_utils as pre_call_utils
+    from litellm.proxy.auth.auth_checks import resolve_team_model_alias
+    from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
+
+    monkeypatch.setenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", "true" if bypass else "false")
+    pre_call_utils._ENABLE_TEAM_STALE_ALIAS_BYPASS = None
+
+    class _MockRouter:
+        model_name_to_deployment_indices = {alias_target: [0]} if live_target else {}
+        team_model_to_deployment_indices = {("team-1", "gpt-4"): [1]} if sibling else {}
+
+    aliases = {"gpt-4": alias_target}
+    test_data = {"model": "gpt-4"}
+    user_api_key_dict = UserAPIKeyAuth(api_key="test_key", team_id="team-1", team_model_aliases=aliases)
+
+    with patch("litellm.proxy.proxy_server.llm_router", _MockRouter()):
+        _update_model_if_team_alias_exists(data=test_data, user_api_key_dict=user_api_key_dict)
+
+    expected = resolve_team_model_alias(
+        model="gpt-4", team_model_aliases=aliases, team_id="team-1", llm_router=_MockRouter(), stale_alias_bypass=bypass
+    )
+    assert test_data["model"] == expected.model
+
+
 def test_warn_stale_team_alias_once_logs_once_per_key(monkeypatch):
     from collections import OrderedDict
 

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -6261,6 +6261,7 @@ def test_team_alias_targeting_live_team_deployment_still_rewrites(monkeypatch):
 )
 def test_team_alias_rewrite_matches_auth_resolution(monkeypatch, alias_target, live_target, sibling, bypass):
     """Routing rewrites the model to exactly what the auth resolver reports."""
+    from litellm.proxy import proxy_server
     from litellm.proxy.auth.auth_checks import resolve_team_model_alias, stale_team_alias_bypass_enabled
     from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
 
@@ -6275,8 +6276,8 @@ def test_team_alias_rewrite_matches_auth_resolution(monkeypatch, alias_target, l
     test_data = {"model": "gpt-4"}
     user_api_key_dict = UserAPIKeyAuth(api_key="test_key", team_id="team-1", team_model_aliases=aliases)
 
-    with patch("litellm.proxy.proxy_server.llm_router", _MockRouter()):
-        _update_model_if_team_alias_exists(data=test_data, user_api_key_dict=user_api_key_dict)
+    monkeypatch.setattr(proxy_server, "llm_router", _MockRouter())
+    _update_model_if_team_alias_exists(data=test_data, user_api_key_dict=user_api_key_dict)
 
     assert stale_team_alias_bypass_enabled() is bypass
     expected = resolve_team_model_alias(


### PR DESCRIPTION
## TLDR

Problem this solves:

- A team model alias satisfied the model access check on its own
- A key scoped to some of the team's models could call every aliased model
- The bypass applied to the key check and the team check alike

How it solves it:

- The alias is resolved to its target before the allowlist check
- The target goes through the same allowlist, wildcard and access group rules as a plain name
- Unrestricted keys and the all-team-models sentinel behave as before

## User Flow

Before: a developer holding a key scoped to one model can call a more expensive team model by using the team's alias for it

1. The proxy admin sends POST https://litellm-domain/team/new with `"models": ["claude-haiku", "claude-sonnet"]` and `"model_aliases": {"team-fast": "claude-haiku"}`
2. The admin sends POST https://litellm-domain/key/generate for that team with `"models": ["claude-sonnet"]` and hands the key to the developer
3. The developer sends POST https://litellm-domain/v1/chat/completions with `"model": "team-fast"` using that key
4. The response is HTTP 200 with a completion from claude-haiku, a model the key was never granted, and the spend lands on that key
5. Any key on the team can do the same for every alias the team defines, whatever the key's own model list says

After: the same request is refused, and the key still works for the models it was granted

1. The proxy admin sends POST https://litellm-domain/team/new with `"models": ["claude-haiku", "claude-sonnet"]` and `"model_aliases": {"team-fast": "claude-haiku"}`
2. The admin sends POST https://litellm-domain/key/generate for that team with `"models": ["claude-sonnet"]` and hands the key to the developer
3. The developer sends POST https://litellm-domain/v1/chat/completions with `"model": "team-fast"` using that key
4. The response is HTTP 403 with `key not allowed to access model. This key can only access models=['claude-sonnet']. Tried to access team-fast`
5. The same key sending `"model": "claude-sonnet"` still gets HTTP 200, and a sibling key granted `claude-haiku` still gets HTTP 200 through `team-fast`
6. A key can no longer reach a team model through its alias unless the alias target is on the key's own model list

## Relevant issues

Refiled from #40716, which GitHub auto-closed when the litellm_internal_staging branch was deleted on 2026-09-13; that PR holds the earlier Greptile rounds (5/5 at the current tip) and the resolved threads. The branch is unchanged and merges cleanly into main

No existing issue. The team model alias lookup in the model access check returned an allow as soon as the requested name was an alias key, without ever comparing the alias target against the calling entity's model list. A key created with a narrower `models` list than its team therefore inherited access to every aliased team model, and a team whose own `models` list did not contain an alias target was still allowed through that alias

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The tip 21b7a17bf6 only changes one test (a patch call became monkeypatch.setattr to keep the test-quality budget flat), so the After run captured at 2d348404de still describes the production tree byte for byte

Setup shared by both runs. Proxy started from the worktree with `uv run python litellm/proxy/proxy_cli.py --config config.yaml --port 4101` against a fresh `postgres:16` container. The two deployments hit a real Anthropic-compatible gateway, so every 200 below cost real tokens

```yaml
model_list:
  - model_name: claude-haiku
    litellm_params:
      model: anthropic/as-anthropic/claude-haiku-4-5-20251001
      api_key: os.environ/ANTHROPIC_API_KEY
      api_base: os.environ/ANTHROPIC_API_BASE
  - model_name: claude-sonnet
    litellm_params:
      model: anthropic/as-anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY
      api_base: os.environ/ANTHROPIC_API_BASE
general_settings:
  master_key: sk-up-team-alias-master
  database_url: postgresql://postgres:uppw@localhost:5441/litellm
```

Team and keys are created the same way on both sides. `$M` is the master key header, `$TEAM` is the id returned by `/team/new`, and the chat payload is always `{"model": ..., "messages": [{"role": "user", "content": "Reply with the single word ok"}], "max_tokens": 5}`

```bash
curl -s http://localhost:4101/team/new -H "$M" -H 'Content-Type: application/json' \
  -d '{"team_alias":"alias-demo","models":["claude-haiku","claude-sonnet"],"model_aliases":{"team-fast":"claude-haiku"}}'
curl -s http://localhost:4101/key/generate -H "$M" -H 'Content-Type: application/json' \
  -d "{\"team_id\":\"$TEAM\",\"models\":[\"claude-sonnet\"],\"key_alias\":\"sonnet-only\"}"
curl -s http://localhost:4101/key/generate -H "$M" -H 'Content-Type: application/json' \
  -d "{\"team_id\":\"$TEAM\",\"models\":[\"claude-haiku\"],\"key_alias\":\"haiku\"}"
```

### Before (9a715df212)

#### Key scoped to claude-sonnet calls the team alias team-fast

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $SONNET_ONLY_KEY" -H 'Content-Type: application/json' -d '{"model":"team-fast", ...}'`
2. Observed: `{"model": "team-fast", "content": "ok", "usage": 17}` and `HTTP 200`. The key was granted `claude-sonnet` only, yet the alias took it to `claude-haiku`

#### Key granted claude-haiku calls the team alias team-fast

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $HAIKU_KEY" -H 'Content-Type: application/json' -d '{"model":"team-fast", ...}'`
2. Observed: `{"model": "team-fast", "content": "ok", "usage": 17}` and `HTTP 200`

### After (2d348404de)

#### Key scoped to claude-sonnet calls the team alias team-fast

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $SONNET_ONLY_KEY" -H 'Content-Type: application/json' -d '{"model":"team-fast", ...}'`
2. Observed: `{"error": {"message": "key not allowed to access model. This key can only access models=['claude-sonnet']. Tried to access team-fast", "type": "key_model_access_denied", "param": "model", "code": "403"}}` and `HTTP 403`

#### Key scoped to claude-sonnet calls its own model

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $SONNET_ONLY_KEY" -H 'Content-Type: application/json' -d '{"model":"claude-sonnet", ...}'`
2. Observed: `{"model": "claude-sonnet", "content": "ok", "usage": 19}` and `HTTP 200`

#### Key granted claude-haiku calls the team alias team-fast

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $HAIKU_KEY" -H 'Content-Type: application/json' -d '{"model":"team-fast", ...}'`
2. Observed: `{"model": "team-fast", "content": "ok", "usage": 17}` and `HTTP 200`

#### Stale alias: key allowed only the deleted team-scoped target requests the alias name

Setup for this case only: a second team with no model restriction, an alias from the real gateway model `claude-haiku` to a team-scoped internal name that has no deployment, and two keys on that team

1. `curl -s http://localhost:4101/team/new -H "$M" -H 'Content-Type: application/json' -d '{"team_alias":"stale-demo","models":[]}'` returns `$TEAM2`
2. `curl -s http://localhost:4101/team/update -H "$M" -H 'Content-Type: application/json' -d "{\"team_id\":\"$TEAM2\",\"model_aliases\":{\"claude-haiku\":\"model_name_${TEAM2}_deadbeef\"}}"`
3. `curl -s http://localhost:4101/key/generate -H "$M" -H 'Content-Type: application/json' -d "{\"team_id\":\"$TEAM2\",\"models\":[\"model_name_${TEAM2}_deadbeef\"]}"` returns `$STALE_KEY`
4. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $STALE_KEY" -H 'Content-Type: application/json' -d '{"model":"claude-haiku", ...}'`
5. Observed: `{"error": {"message": "key not allowed to access model. This key can only access models=['model_name_ac60036a-942b-44f5-80aa-594d53084b2a_deadbeef']. Tried to access claude-haiku", "type": "key_model_access_denied", "param": "model", "code": "403"}}` and `HTTP 403`; the proxy log carries one `targets '...deadbeef', which has no live deployment. Routing with the requested model name instead` warning, so routing and authorization looked at the same name

#### Stale alias: key granted the requested name on the same team

1. `curl -s http://localhost:4101/key/generate -H "$M" -H 'Content-Type: application/json' -d "{\"team_id\":\"$TEAM2\",\"models\":[\"claude-haiku\"]}"` returns `$STALE_OK_KEY`
2. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $STALE_OK_KEY" -H 'Content-Type: application/json' -d '{"model":"claude-haiku", ...}'`
3. Observed: `{"model": "claude-haiku", "content": "ok", "usage": 17}` and `HTTP 200`

## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- Keys that relied on an alias to reach a model outside their own list now get 403
- Teams whose `models` list omits an alias target now get 403 through that alias

### Low

- Team aliases are authorized against the name routing will actually use: when the alias target is a deleted team-scoped deployment, or the stale alias bypass keeps the team's sibling deployments reachable, the requested name is checked instead of the stored target. Both paths share one resolver so they cannot drift apart again
- The header forwarding lookup by model group shares the helper and now resolves aliases to their target too
- A team alias name is no longer matched against the allowlist itself, and it is not resolved through the router or global alias maps; only its target is, so a name that is both a team alias and a router alias follows the team alias, as request routing already does

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
