### PR TITLE
fix(dashscope): map thinking and reasoning_effort to DashScope fields

### DIFF
--- a/litellm/llms/dashscope/chat/transformation.py
+++ b/litellm/llms/dashscope/chat/transformation.py
@@ -2,7 +2,7 @@
 Translates from OpenAI's `/v1/chat/completions` to DashScope's `/v1/chat/completions`
 """
 
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Mapping
 from types import MappingProxyType
 from typing import Any, Final, Literal, overload
 
@@ -111,11 +111,11 @@ class DashScopeChatConfig(OpenAIGPTConfig):
 
     def _map_openai_params(
         self,
-        non_default_params: dict,
-        optional_params: dict,
+        non_default_params: dict[str, object],
+        optional_params: dict[str, object],
         model: str,
         drop_params: bool,
-    ) -> dict:
+    ) -> dict[str, object]:
         supported_openai_params: Final = frozenset(self.get_supported_openai_params(model))
         passthrough_params: Final = MappingProxyType(
             {
@@ -130,7 +130,7 @@ class DashScopeChatConfig(OpenAIGPTConfig):
         if not native:
             return {**optional_params, **passthrough_params}  # mutable-ok: dict return contract of OpenAIGPTConfig
         existing: Final = optional_params.get("extra_body")
-        existing_body: Final = existing if isinstance(existing, dict) else MappingProxyType({})
+        existing_body: Final = existing if isinstance(existing, Mapping) else MappingProxyType({})
         return {  # mutable-ok: dict return contract of OpenAIGPTConfig
             **optional_params,
             **passthrough_params,

--- a/litellm/llms/dashscope/chat/transformation.py
+++ b/litellm/llms/dashscope/chat/transformation.py
@@ -3,12 +3,43 @@ Translates from OpenAI's `/v1/chat/completions` to DashScope's `/v1/chat/complet
 """
 
 from collections.abc import Coroutine
+from types import MappingProxyType
 from typing import Any, Final, Literal, overload
+
+from typing_extensions import ReadOnly, TypedDict
 
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
+
+THINKING_OFF_REASONING_EFFORTS: Final = frozenset({"none", "disable"})
+DASHSCOPE_THINKING_PARAMS: Final = frozenset({"thinking", "reasoning_effort"})
+
+
+class DashScopeThinkingBody(TypedDict, total=False):
+    enable_thinking: ReadOnly[bool]
+    thinking_budget: ReadOnly[int]
+    reasoning_effort: ReadOnly[str]
+
+
+def _dashscope_thinking_body(thinking: object, reasoning_effort: object) -> DashScopeThinkingBody:
+    if isinstance(thinking, dict):
+        enabled: Final = thinking.get("type") != "disabled"
+        budget: Final = thinking.get("budget_tokens")
+        if isinstance(budget, int) and not isinstance(budget, bool):
+            with_budget: Final[DashScopeThinkingBody] = {"enable_thinking": enabled, "thinking_budget": budget}
+            return with_budget
+        toggled: Final[DashScopeThinkingBody] = {"enable_thinking": enabled}
+        return toggled
+    if isinstance(reasoning_effort, str):
+        if reasoning_effort in THINKING_OFF_REASONING_EFFORTS:
+            off: Final[DashScopeThinkingBody] = {"enable_thinking": False}
+            return off
+        with_effort: Final[DashScopeThinkingBody] = {"enable_thinking": True, "reasoning_effort": reasoning_effort}
+        return with_effort
+    untouched: Final[DashScopeThinkingBody] = {}
+    return untouched
 
 
 class DashScopeChatConfig(OpenAIGPTConfig):
@@ -73,3 +104,35 @@ class DashScopeChatConfig(OpenAIGPTConfig):
         if resolved_api_base.endswith("/chat/completions"):
             return resolved_api_base
         return f"{resolved_api_base}/chat/completions"
+
+    def get_supported_openai_params(self, model: str) -> list:
+        base_params: Final = super().get_supported_openai_params(model)
+        return [*base_params, "thinking", "reasoning_effort"]  # mutable-ok: inherited list contract
+
+    def _map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        supported_openai_params: Final = frozenset(self.get_supported_openai_params(model))
+        passthrough_params: Final = MappingProxyType(
+            {
+                k: v
+                for k, v in non_default_params.items()
+                if k in supported_openai_params and k not in DASHSCOPE_THINKING_PARAMS
+            }
+        )
+        native: Final = _dashscope_thinking_body(
+            non_default_params.get("thinking"), non_default_params.get("reasoning_effort")
+        )
+        if not native:
+            return {**optional_params, **passthrough_params}  # mutable-ok: dict return contract of OpenAIGPTConfig
+        existing: Final = optional_params.get("extra_body")
+        existing_body: Final = existing if isinstance(existing, dict) else MappingProxyType({})
+        return {  # mutable-ok: dict return contract of OpenAIGPTConfig
+            **optional_params,
+            **passthrough_params,
+            "extra_body": {**existing_body, **native},  # mutable-ok: the OpenAI SDK json-encodes extra_body from a dict
+        }

--- a/litellm/llms/dashscope/chat/transformation.py
+++ b/litellm/llms/dashscope/chat/transformation.py
@@ -27,7 +27,7 @@ def _dashscope_thinking_body(thinking: object, reasoning_effort: object) -> Dash
     if isinstance(thinking, dict):
         enabled: Final = thinking.get("type") != "disabled"
         budget: Final = thinking.get("budget_tokens")
-        if isinstance(budget, int) and not isinstance(budget, bool):
+        if enabled and isinstance(budget, int) and not isinstance(budget, bool):
             with_budget: Final[DashScopeThinkingBody] = {"enable_thinking": enabled, "thinking_budget": budget}
             return with_budget
         toggled: Final[DashScopeThinkingBody] = {"enable_thinking": enabled}

--- a/tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py
@@ -7,12 +7,14 @@ DashScope is an OpenAI-compatible provider with minor customizations.
 
 
 
-from litellm.types.llms.openai import AllMessageValues
+import json
+
 import pytest
 
 import litellm
 from litellm import completion
 from litellm.llms.dashscope.chat.transformation import DashScopeChatConfig
+from litellm.types.llms.openai import AllMessageValues
 
 
 class TestDashScopeConfig:
@@ -185,3 +187,125 @@ class TestDashScopeConfig:
         )
 
         assert transformed_tools[0].get("cache_control") == {"type": "ephemeral"}
+
+
+class TestDashScopeThinkingParams:
+    """thinking and reasoning_effort reach DashScope as enable_thinking, thinking_budget and reasoning_effort."""
+
+    @staticmethod
+    def _map(**non_default_params) -> dict:
+        return DashScopeChatConfig().map_openai_params(
+            non_default_params=non_default_params,
+            optional_params={},
+            model="qwen3.8-max",
+            drop_params=False,
+        )
+
+    @pytest.mark.parametrize(
+        ("thinking", "expected"),
+        [
+            ({"type": "enabled", "budget_tokens": 4096}, {"enable_thinking": True, "thinking_budget": 4096}),
+            ({"type": "enabled"}, {"enable_thinking": True}),
+            ({"type": "disabled"}, {"enable_thinking": False}),
+        ],
+    )
+    def test_thinking_maps_to_enable_thinking_and_budget(self, thinking, expected):
+        assert self._map(thinking=thinking)["extra_body"] == expected
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "minimal"])
+    def test_reasoning_effort_enables_thinking_and_is_forwarded(self, effort):
+        params = self._map(reasoning_effort=effort)
+
+        assert params["extra_body"] == {"enable_thinking": True, "reasoning_effort": effort}
+
+    @pytest.mark.parametrize("effort", ["none", "disable"])
+    def test_reasoning_effort_off_disables_thinking(self, effort):
+        assert self._map(reasoning_effort=effort)["extra_body"] == {"enable_thinking": False}
+
+    def test_thinking_budget_wins_over_reasoning_effort(self):
+        params = self._map(thinking={"type": "enabled", "budget_tokens": 512}, reasoning_effort="high")
+
+        assert params["extra_body"] == {"enable_thinking": True, "thinking_budget": 512}
+
+    def test_no_thinking_params_leaves_extra_body_absent(self):
+        params = self._map(temperature=0.5, max_tokens=16)
+
+        assert "extra_body" not in params
+        assert params["temperature"] == 0.5
+        assert params["max_tokens"] == 16
+
+    def test_thinking_params_never_become_top_level_kwargs(self):
+        params = self._map(thinking={"type": "enabled"}, reasoning_effort="high")
+
+        assert "thinking" not in params
+        assert "reasoning_effort" not in params
+
+    def test_existing_extra_body_is_preserved_and_not_mutated(self):
+        caller_extra_body = {"enable_search": True}
+        params = DashScopeChatConfig().map_openai_params(
+            non_default_params={"thinking": {"type": "enabled"}},
+            optional_params={"extra_body": caller_extra_body},
+            model="qwen3.8-max",
+            drop_params=False,
+        )
+
+        assert params["extra_body"] == {"enable_search": True, "enable_thinking": True}
+        assert caller_extra_body == {"enable_search": True}
+
+    def test_caller_optional_params_are_not_mutated(self):
+        caller_optional_params = {"temperature": 0.2, "extra_body": {"enable_search": True}}
+        params = DashScopeChatConfig().map_openai_params(
+            non_default_params={"thinking": {"type": "disabled"}, "max_tokens": 8},
+            optional_params=caller_optional_params,
+            model="qwen3.8-max",
+            drop_params=False,
+        )
+
+        assert params == {
+            "temperature": 0.2,
+            "max_tokens": 8,
+            "extra_body": {"enable_search": True, "enable_thinking": False},
+        }
+        assert params is not caller_optional_params
+        assert caller_optional_params == {"temperature": 0.2, "extra_body": {"enable_search": True}}
+
+    def test_get_optional_params_accepts_thinking_without_drop_params(self):
+        params = litellm.get_optional_params(
+            model="qwen3.8-max",
+            custom_llm_provider="dashscope",
+            thinking={"type": "disabled"},
+            drop_params=False,
+        )
+
+        assert params["extra_body"]["enable_thinking"] is False
+        assert "thinking" not in params
+
+    @pytest.mark.respx()
+    def test_thinking_disabled_reaches_the_wire_as_enable_thinking(self, respx_mock):
+        litellm.disable_aiohttp_transport = True
+        api_base = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+        route = respx_mock.post(f"{api_base}/chat/completions").respond(
+            json={
+                "id": "chatcmpl-456",
+                "object": "chat.completion",
+                "created": 1677652288,
+                "model": "qwen3.8-max",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "4"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 9, "completion_tokens": 1, "total_tokens": 10},
+            },
+            status_code=200,
+        )
+
+        completion(
+            model="dashscope/qwen3.8-max",
+            messages=[{"role": "user", "content": "2+2?"}],
+            api_key="fake-dashscope-key",
+            api_base=api_base,
+            thinking={"type": "disabled"},
+            drop_params=False,
+        )
+
+        sent = json.loads(route.calls.last.request.content)
+        assert sent["enable_thinking"] is False
+        assert "thinking" not in sent
+        assert "extra_body" not in sent

--- a/tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py
@@ -207,6 +207,7 @@ class TestDashScopeThinkingParams:
             ({"type": "enabled", "budget_tokens": 4096}, {"enable_thinking": True, "thinking_budget": 4096}),
             ({"type": "enabled"}, {"enable_thinking": True}),
             ({"type": "disabled"}, {"enable_thinking": False}),
+            ({"type": "disabled", "budget_tokens": 4096}, {"enable_thinking": False}),
         ],
     )
     def test_thinking_maps_to_enable_thinking_and_budget(self, thinking, expected):

--- a/tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py
@@ -193,7 +193,7 @@ class TestDashScopeThinkingParams:
     """thinking and reasoning_effort reach DashScope as enable_thinking, thinking_budget and reasoning_effort."""
 
     @staticmethod
-    def _map(**non_default_params) -> dict:
+    def _map(**non_default_params: object) -> dict[str, object]:
         return DashScopeChatConfig().map_openai_params(
             non_default_params=non_default_params,
             optional_params={},


### PR DESCRIPTION
## TLDR

Problem this solves:

- `thinking` and `reasoning_effort` never reach DashScope
- Without `drop_params` the proxy answers 400 UnsupportedParamsError
- With `drop_params` both are dropped and Qwen keeps thinking on by default
- Every Qwen 3.5 and later call pays for reasoning tokens the caller tried to turn off

How it solves it:

- DashScope accepts `thinking` and `reasoning_effort` as supported params
- `thinking` maps to `enable_thinking` plus `thinking_budget`
- `reasoning_effort` `none` or `disable` maps to `enable_thinking: false`, other values are forwarded
- The fields travel in `extra_body`, merged with any caller-supplied `extra_body`

## User Flow

Before: a developer routing a Qwen model through the proxy cannot turn thinking off, so every request either fails or bills reasoning tokens

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "qwen3.8-max"` and `"thinking": {"type": "disabled"}`
2. The proxy answers HTTP 400 `dashscope does not support parameters: ['thinking']`
3. They switch the deployment to `drop_params: true` and send the same request
4. The proxy answers HTTP 200, but the response still carries `reasoning_content` and the reasoning tokens show up in `usage`
5. They open https://litellm-domain/ui/?page=logs and see every request billed for reasoning they asked to skip

After: the same request turns thinking off and the bill only covers the answer

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "qwen3.8-max"` and `"thinking": {"type": "disabled"}`
2. The proxy answers HTTP 200 with no `reasoning_content` and no reasoning tokens in `usage`
3. Sending `"reasoning_effort": "low"` instead also answers HTTP 200 and the model reasons at the low setting
4. https://litellm-domain/ui/?page=logs shows the request at answer-only spend

## Relevant issues

Refiled from #40720, which GitHub auto-closed when the litellm_internal_staging branch was deleted on 2026-09-13; that PR holds the earlier Greptile rounds (5/5 at the current tip) and the resolved threads. The branch is unchanged and merges cleanly into main

No existing issue. `DashScopeChatConfig` inherits the OpenAI supported-params list, which carries neither `thinking` nor `reasoning_effort`, so both are discarded before the request leaves the proxy. DashScope spells these controls `enable_thinking`, `thinking_budget` and `reasoning_effort` in the request body (vendor reference: https://help.aliyun.com/zh/model-studio/qwen-api-via-openai-chat-completions), and every Qwen 3.5 and later hybrid model defaults thinking on, so a caller who cannot turn it off pays for reasoning tokens on every request

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4104, started with `uv run python litellm/proxy/proxy_cli.py --config proxy_config.yaml --port 4104`. No DashScope credential was available in this environment, so the deployment's `api_base` points at a local HTTP endpoint on port 4114 that records the JSON body the proxy sends and echoes the thinking-related keys it received back as the assistant message. That makes the request body that leaves the proxy visible in the curl output. Everything in front of that endpoint is the real proxy and the real DashScope request pipeline

```yaml
model_list:
  - model_name: qwen3.8-max
    litellm_params:
      model: dashscope/qwen3.8-max
      api_base: http://127.0.0.1:4114/compatible-mode/v1
      api_key: sk-capture-only
  - model_name: qwen3.8-max-drop-params
    litellm_params:
      model: dashscope/qwen3.8-max
      api_base: http://127.0.0.1:4114/compatible-mode/v1
      api_key: sk-capture-only
      drop_params: true

general_settings:
  master_key: sk-1234
```

### Before (9a715df212)

#### thinking disabled

1. `curl -s http://localhost:4104/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"qwen3.8-max","messages":[{"role":"user","content":"2+2?"}],"thinking":{"type":"disabled"}}'`
2. HTTP 400 `{"error": {"message": "litellm.UnsupportedParamsError: dashscope does not support parameters: ['thinking'], for model=qwen3.8-max. To drop these, set litellm.drop_params=True ...", "type": "invalid_request_error", "code": "400"}}`

#### reasoning_effort low

1. `curl -s http://localhost:4104/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"qwen3.8-max","messages":[{"role":"user","content":"2+2?"}],"reasoning_effort":"low"}'`
2. HTTP 400 `{"error": {"message": "litellm.UnsupportedParamsError: dashscope does not support parameters: ['reasoning_effort'], for model=qwen3.8-max. ...", "type": "invalid_request_error", "code": "400"}}`

#### thinking disabled on a deployment with drop_params true

1. `curl -s http://localhost:4104/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"qwen3.8-max-drop-params","messages":[{"role":"user","content":"2+2?"}],"thinking":{"type":"disabled"}}'`
2. HTTP 200 `{"choices": [{"message": {"content": "provider received: {}"}}]}`
3. The body that reached the provider endpoint carried no `enable_thinking`, so the model would keep its default thinking on

#### baseline without thinking params

1. `curl -s http://localhost:4104/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"qwen3.8-max","messages":[{"role":"user","content":"2+2?"}]}'`
2. HTTP 200 `{"choices": [{"message": {"content": "provider received: {}"}}]}`

### After (0f7ae36521)

#### thinking disabled

1. `curl -s http://localhost:4104/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"qwen3.8-max","messages":[{"role":"user","content":"2+2?"}],"thinking":{"type":"disabled"}}'`
2. HTTP 200 `{"choices": [{"message": {"content": "provider received: {\"enable_thinking\": false}"}}]}`
3. Provider-side body: `{"enable_thinking": false}`, no top-level `thinking`, no `extra_body` wrapper

#### reasoning_effort low

1. `curl -s http://localhost:4104/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"qwen3.8-max","messages":[{"role":"user","content":"2+2?"}],"reasoning_effort":"low"}'`
2. HTTP 200 `{"choices": [{"message": {"content": "provider received: {\"enable_thinking\": true, \"reasoning_effort\": \"low\"}"}}]}`
3. Provider-side body: `{"enable_thinking": true, "reasoning_effort": "low"}`

#### thinking disabled on a deployment with drop_params true

1. `curl -s http://localhost:4104/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"qwen3.8-max-drop-params","messages":[{"role":"user","content":"2+2?"}],"thinking":{"type":"disabled"}}'`
2. HTTP 200 `{"choices": [{"message": {"content": "provider received: {\"enable_thinking\": false}"}}]}`
3. Provider-side body: `{"enable_thinking": false}`

#### baseline without thinking params

1. `curl -s http://localhost:4104/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"qwen3.8-max","messages":[{"role":"user","content":"2+2?"}]}'`
2. HTTP 200 `{"choices": [{"message": {"content": "provider received: {}"}}]}`
3. Provider-side body unchanged: no thinking-related keys are injected when the caller sends none

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Proof of fix captures the request body the proxy sends; it was not run against a live DashScope key
- The qwen3.8 series rejects `reasoning_effort` together with `thinking_budget`, so `thinking` wins when both are sent

### Low

- `reasoning_effort` values are forwarded as is; DashScope validates them per model

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
