### PR TITLE
feat(anthropic-bridge): opt-in demotion or dropping of mid-turn system messages

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -5,6 +5,7 @@ Common utility functions used for translating messages across providers
 import io
 import json
 import mimetypes
+import os
 import re
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from itertools import groupby, islice
@@ -33,6 +34,7 @@ from litellm.types.llms.openai import (
     ChatCompletionReasoningSummaryTextBlock,
     ChatCompletionRedactedThinkingBlock,
     ChatCompletionResponseMessage,
+    ChatCompletionSystemMessage,
     ChatCompletionTextObject,
     ChatCompletionThinkingBlock,
     ChatCompletionToolParam,
@@ -131,6 +133,65 @@ def strip_none_values_from_message(message: AllMessageValues) -> AllMessageValue
     Strips None values from message
     """
     return cast(AllMessageValues, {k: v for k, v in message.items() if v is not None})
+
+
+DEMOTE_MIDTURN_SYSTEM_ENV: Final = "LITELLM_DEMOTE_MIDTURN_SYSTEM"
+
+
+def demote_or_drop_midturn_system_messages(
+    messages: list[AllMessageValues],  # mutable-ok: mirrors ChatCompletionRequest.messages
+) -> list[AllMessageValues]:  # mutable-ok: ChatCompletionRequest.messages requires a list
+    """Opt-in normalization of ``system`` rows that appear after index 0.
+
+    OpenAI accepts ``system`` messages anywhere in a conversation, but many
+    OpenAI-compatible backends enforce chat templates that reject a non-leading
+    system row (e.g. Qwen3 served by vLLM: "System message must be at the
+    beginning."). Clients that send mid-conversation system messages — Claude
+    Code's reminder turns, or an SDK that appends a JSON-schema/output
+    instruction as a trailing system row — 400 against such backends.
+
+    Gated on the ``LITELLM_DEMOTE_MIDTURN_SYSTEM`` env var:
+
+    - ``"true"`` / ``"demote"`` — rewrite each in-sequence system row as a
+      ``user`` row (preserving its content), matching how such reminders were
+      historically delivered.
+    - ``"drop"`` — remove them entirely, for backends where the content is not
+      wanted and a stable leading prefix caches better.
+    - anything else (default) — return ``messages`` unchanged.
+
+    The leading system row (index 0) is always preserved. Idempotent: after one
+    pass there are no non-leading system rows, so re-running is a no-op — safe
+    to call on paths that may already have been normalized.
+
+    Caveat — ``drop`` is content-lossy by design. If a server-side hook
+    (e.g. a guardrail) injects a trusted advisory as a *mid-sequence* system
+    row before this runs, ``drop`` removes it along with client reminders,
+    which can weaken a downstream policy that relies on that advisory. This
+    only affects non-leading system rows: an advisory prepended to the leading
+    system message (index 0) is always kept. When such hook-injected content
+    must survive, use ``demote`` (or ``true``) instead — it preserves every
+    system row's content, relocated to a ``user`` row. Both modes are opt-in
+    and off by default, so neither changes behavior unless explicitly enabled.
+    """
+    mode: Final = os.environ.get(DEMOTE_MIDTURN_SYSTEM_ENV, "").strip().lower()
+    if mode not in ("true", "demote", "drop"):
+        return messages
+    if mode == "drop":
+        return [  # mutable-ok: ChatCompletionRequest.messages requires a list
+            message for index, message in enumerate(messages) if index == 0 or message.get("role") != "system"
+        ]
+    return [  # mutable-ok: ChatCompletionRequest.messages requires a list
+        ChatCompletionUserMessage(
+            role="user",
+            content=cast(  # cast-ok: the role == "system" guard narrows this row
+                ChatCompletionSystemMessage, message
+            ).get("content")
+            or "",
+        )
+        if index > 0 and message.get("role") == "system"
+        else message
+        for index, message in enumerate(messages)
+    ]
 
 
 def extract_search_results_text(search_results: object) -> str:

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1,6 +1,7 @@
 import copy
 import hashlib
 import json
+import os
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, TypeVar, cast
 
@@ -881,6 +882,43 @@ class LiteLLMAnthropicMessagesAdapter:
             text_parts.append(self._add_prompt_cache_breakpoint_if_present(block, text_obj))
         return ChatCompletionSystemMessage(role="system", content=text_parts) if text_parts else None
 
+    def _demote_midturn_system_messages(
+        self,
+        new_messages: list[AllMessageValues],  # mutable-ok: matches ChatCompletionRequest.messages
+    ) -> list[AllMessageValues]:  # mutable-ok: ChatCompletionRequest.messages requires a list
+        """Return the messages with system entries after index 0 rewritten or removed, opt-in.
+
+        Gated on LITELLM_DEMOTE_MIDTURN_SYSTEM: "true" (or "demote") rewrites
+        each in-sequence system row as a user row, "drop" removes them
+        entirely, anything else leaves the messages untouched. OpenAI accepts
+        system messages anywhere in the conversation, but many
+        OpenAI-compatible backends enforce chat templates that reject
+        non-leading system rows (e.g. Qwen3 served by vLLM: "System message
+        must be at the beginning."). Clients like Claude Code send mid-turn
+        system reminders, so without this those requests 400. Demoting to a
+        user row mirrors how such reminders were historically delivered;
+        dropping trades their content for a prompt the backend caches better.
+        """
+        mode: Final = os.environ.get("LITELLM_DEMOTE_MIDTURN_SYSTEM", "").strip().lower()
+        if mode not in ("true", "demote", "drop"):
+            return new_messages
+        if mode == "drop":
+            return [  # mutable-ok: ChatCompletionRequest.messages requires a list
+                message for index, message in enumerate(new_messages) if index == 0 or message.get("role") != "system"
+            ]
+        return [  # mutable-ok: ChatCompletionRequest.messages requires a list
+            ChatCompletionUserMessage(
+                role="user",
+                content=cast(  # cast-ok: the role == "system" guard narrows this row
+                    ChatCompletionSystemMessage, message
+                ).get("content")
+                or "",
+            )
+            if index > 0 and message.get("role") == "system"
+            else message
+            for index, message in enumerate(new_messages)
+        ]
+
     def _add_system_message_to_messages(
         self,
         new_messages: list[AllMessageValues],
@@ -1178,10 +1216,11 @@ class LiteLLMAnthropicMessagesAdapter:
         )
         ## ADD SYSTEM MESSAGE TO MESSAGES
         self._add_system_message_to_messages(new_messages, anthropic_message_request)
+        final_messages: Final = self._demote_midturn_system_messages(new_messages)
 
         new_kwargs: Final[ChatCompletionRequest] = {
             "model": anthropic_message_request["model"],
-            "messages": new_messages,
+            "messages": final_messages,
         }
         ## CONVERT METADATA (user_id + litellm metadata)
         self._translate_metadata_to_openai(

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1,7 +1,6 @@
 import copy
 import hashlib
 import json
-import os
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, TypeVar, cast
 
@@ -101,6 +100,7 @@ from openai.types.chat.chat_completion_chunk import Choice as OpenAIStreamingCho
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     anthropic_image_source_to_openai_url,
+    demote_or_drop_midturn_system_messages,
     parse_tool_call_arguments,
     reasoning_content_from_thinking_blocks,
     with_prompt_cache_breakpoint,
@@ -886,38 +886,11 @@ class LiteLLMAnthropicMessagesAdapter:
         self,
         new_messages: list[AllMessageValues],  # mutable-ok: matches ChatCompletionRequest.messages
     ) -> list[AllMessageValues]:  # mutable-ok: ChatCompletionRequest.messages requires a list
-        """Return the messages with system entries after index 0 rewritten or removed, opt-in.
-
-        Gated on LITELLM_DEMOTE_MIDTURN_SYSTEM: "true" (or "demote") rewrites
-        each in-sequence system row as a user row, "drop" removes them
-        entirely, anything else leaves the messages untouched. OpenAI accepts
-        system messages anywhere in the conversation, but many
-        OpenAI-compatible backends enforce chat templates that reject
-        non-leading system rows (e.g. Qwen3 served by vLLM: "System message
-        must be at the beginning."). Clients like Claude Code send mid-turn
-        system reminders, so without this those requests 400. Demoting to a
-        user row mirrors how such reminders were historically delivered;
-        dropping trades their content for a prompt the backend caches better.
-        """
-        mode: Final = os.environ.get("LITELLM_DEMOTE_MIDTURN_SYSTEM", "").strip().lower()
-        if mode not in ("true", "demote", "drop"):
-            return new_messages
-        if mode == "drop":
-            return [  # mutable-ok: ChatCompletionRequest.messages requires a list
-                message for index, message in enumerate(new_messages) if index == 0 or message.get("role") != "system"
-            ]
-        return [  # mutable-ok: ChatCompletionRequest.messages requires a list
-            ChatCompletionUserMessage(
-                role="user",
-                content=cast(  # cast-ok: the role == "system" guard narrows this row
-                    ChatCompletionSystemMessage, message
-                ).get("content")
-                or "",
-            )
-            if index > 0 and message.get("role") == "system"
-            else message
-            for index, message in enumerate(new_messages)
-        ]
+        """Opt-in demotion/dropping of in-sequence system rows on the Anthropic
+        bridge. Delegates to the shared helper so the OpenAI /chat/completions
+        path (hosted_vllm) honors the same LITELLM_DEMOTE_MIDTURN_SYSTEM flag;
+        see litellm_core_utils.prompt_templates.common_utils."""
+        return demote_or_drop_midturn_system_messages(new_messages)
 
     def _add_system_message_to_messages(
         self,

--- a/litellm/llms/hosted_vllm/chat/transformation.py
+++ b/litellm/llms/hosted_vllm/chat/transformation.py
@@ -8,6 +8,7 @@ from typing import Any, Final, Literal, cast, overload
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     _get_image_mime_type_from_url,
+    demote_or_drop_midturn_system_messages,
 )
 from litellm.litellm_core_utils.prompt_templates.factory import _parse_mime_type
 from litellm.litellm_core_utils.reasoning_effort_utils import (
@@ -234,6 +235,13 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
                                 replaced_content_items.append((idx, content_item))
                     for idx, content_item in replaced_content_items:
                         message_content[idx] = self._convert_file_to_video_url(content_item)
+
+        # vLLM chat templates commonly reject a system row that isn't first
+        # (Qwen3: "System message must be at the beginning."). Opt-in via
+        # LITELLM_DEMOTE_MIDTURN_SYSTEM — the same flag the Anthropic bridge
+        # honors — so OpenAI-SDK clients that send a mid-turn / trailing system
+        # message don't 400 here. No-op unless the flag is set.
+        messages = demote_or_drop_midturn_system_messages(messages)  # rebind-ok: normalized list to super()
 
         if is_async:
             return super()._transform_messages(messages, model, is_async=cast(Literal[True], True))

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -13,6 +13,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
     TOOL_RESULT_IMAGE_BOUNDARY,
     TOOL_RESULT_IMAGE_PLACEHOLDER,
     add_system_prompt_to_messages,
+    demote_or_drop_midturn_system_messages,
     encrypted_content_from_signature,
     encrypted_reasoning_signature,
     get_file_ids_from_messages,
@@ -1813,3 +1814,42 @@ class TestEncryptedReasoningReplay:
         strip_encrypted_reasoning_from_messages(messages)
 
         assert messages == before
+
+
+def _midturn_msgs():
+    return [
+        {"role": "system", "content": "lead"},
+        {"role": "user", "content": "hi"},
+        {"role": "system", "content": "trailing schema"},
+    ]
+
+
+class TestDemoteOrDropMidturnSystemMessages:
+    def test_default_unchanged(self, monkeypatch):
+        monkeypatch.delenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", raising=False)
+        out = demote_or_drop_midturn_system_messages(_midturn_msgs())
+        assert [m["role"] for m in out] == ["system", "user", "system"]
+
+    def test_junk_value_unchanged(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", "maybe")
+        out = demote_or_drop_midturn_system_messages(_midturn_msgs())
+        assert [m["role"] for m in out] == ["system", "user", "system"]
+
+    def test_demote_rewrites_as_user(self, monkeypatch):
+        for val in ("true", "demote"):
+            monkeypatch.setenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", val)
+            out = demote_or_drop_midturn_system_messages(_midturn_msgs())
+            assert [m["role"] for m in out] == ["system", "user", "user"]
+            assert out[2]["content"] == "trailing schema"
+
+    def test_drop_removes(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", "drop")
+        out = demote_or_drop_midturn_system_messages(_midturn_msgs())
+        assert [m["role"] for m in out] == ["system", "user"]
+
+    def test_leading_system_preserved_and_idempotent(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", "true")
+        once = demote_or_drop_midturn_system_messages(_midturn_msgs())
+        twice = demote_or_drop_midturn_system_messages(once)
+        assert once == twice  # idempotent
+        assert once[0] == {"role": "system", "content": "lead"}

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -115,9 +115,7 @@ def test_translate_streaming_openai_chunk_to_anthropic_content_block():
                 tool_calls=[
                     ChatCompletionDeltaToolCall(
                         id="call_d581d130-e234-4315-94e8-27e7ff7c4e55",
-                        function=Function(
-                            arguments='{"location": "Boston"}', name="get_weather"
-                        ),
+                        function=Function(arguments='{"location": "Boston"}', name="get_weather"),
                         type="function",
                         index=0,
                     )
@@ -131,9 +129,7 @@ def test_translate_streaming_openai_chunk_to_anthropic_content_block():
     (
         block_type,
         content_block_start,
-    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(
-        choices=choices
-    )
+    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(choices=choices)
 
     print(content_block_start)
 
@@ -163,9 +159,7 @@ def test_translate_streaming_openai_chunk_strips_gemini_thought_from_tool_call_i
                 tool_calls=[
                     ChatCompletionDeltaToolCall(
                         id=combined,
-                        function=Function(
-                            arguments='{"a": 17, "b": 25}', name="add_numbers"
-                        ),
+                        function=Function(arguments='{"a": 17, "b": 25}', name="add_numbers"),
                         type="function",
                         index=0,
                     )
@@ -179,9 +173,7 @@ def test_translate_streaming_openai_chunk_strips_gemini_thought_from_tool_call_i
     (
         block_type,
         content_block_start,
-    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(
-        choices=choices
-    )
+    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(choices=choices)
 
     assert block_type == "tool_use"
     assert content_block_start["id"] == base
@@ -226,9 +218,7 @@ def test_translate_streaming_openai_chunk_to_anthropic_thinking_content_block():
     (
         block_type,
         content_block_start,
-    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(
-        choices=choices
-    )
+    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(choices=choices)
 
     assert block_type == "thinking"
     assert content_block_start == {
@@ -264,9 +254,7 @@ def test_translate_streaming_openai_chunk_to_anthropic_reasoning_content_only_co
     (
         block_type,
         content_block_start,
-    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(
-        choices=choices
-    )
+    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(choices=choices)
 
     assert block_type == "thinking"
     assert content_block_start == {
@@ -312,9 +300,7 @@ def test_translate_streaming_openai_chunk_to_anthropic_thinking_signature_block(
     (
         block_type,
         content_block_start,
-    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(
-        choices=choices
-    )
+    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(choices=choices)
 
     assert block_type == "thinking"
     assert content_block_start == {
@@ -367,9 +353,7 @@ def test_translate_streaming_openai_chunk_to_anthropic_content_block_thinking_an
     (
         block_type,
         content_block_start,
-    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(
-        choices=choices
-    )
+    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(choices=choices)
 
     assert block_type == "thinking"
 
@@ -412,10 +396,7 @@ def test_translate_anthropic_messages_to_openai_thinking_blocks():
     assert "thinking_blocks" in result[1]
     assert len(result[1]["thinking_blocks"]) == 2
     assert result[1]["thinking_blocks"][0]["type"] == "thinking"
-    assert (
-        result[1]["thinking_blocks"][0]["thinking"]
-        == "I will call the get_weather tool."
-    )
+    assert result[1]["thinking_blocks"][0]["thinking"] == "I will call the get_weather tool."
     assert result[1]["thinking_blocks"][0]["signature"] == "sigsig"
     assert result[1]["thinking_blocks"][1]["type"] == "redacted_thinking"
     assert result[1]["thinking_blocks"][1]["data"] == "REDACTED"
@@ -555,9 +536,7 @@ def test_translate_anthropic_messages_to_openai_tool_message_placement():
 
     assert tool_message_idx is not None, "Tool message not found"
     assert user_message_idx is not None, "User message not found"
-    assert (
-        tool_message_idx < user_message_idx
-    ), "Tool message should be placed before user message"
+    assert tool_message_idx < user_message_idx, "Tool message should be placed before user message"
 
 
 @pytest.mark.parametrize(
@@ -899,6 +878,158 @@ def test_translate_anthropic_to_openai_without_metadata_sets_neither_user_nor_pr
     assert "prompt_cache_key" not in openai_request
 
 
+@pytest.mark.parametrize("env_value", ["true", "demote"])
+def test_translate_anthropic_to_openai_demotes_midturn_system_when_enabled(
+    monkeypatch,
+    env_value: str,
+):
+    """
+    With LITELLM_DEMOTE_MIDTURN_SYSTEM=true (alias "demote"), in-sequence system rows are
+    rewritten as user rows so chat templates that reject non-leading system messages
+    (e.g. Qwen3 on vLLM) accept the request. The hoisted top-level prompt at index 0
+    keeps `role: "system"`.
+    """
+    monkeypatch.setenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", env_value)
+
+    openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+        anthropic_message_request={
+            "model": "claude-3-5-sonnet-20240620",
+            "max_tokens": 100,
+            "system": "Trusted top-level prompt.",
+            "messages": [
+                {"role": "user", "content": "First question."},
+                {"role": "assistant", "content": "First answer."},
+                {"role": "system", "content": "Use the corrected result."},
+                {"role": "user", "content": "Continue."},
+            ],
+        }
+    )
+
+    assert openai_request["messages"] == [
+        {"role": "system", "content": "Trusted top-level prompt."},
+        {"role": "user", "content": "First question."},
+        {"role": "assistant", "content": "First answer.", "thinking_blocks": None},
+        {"role": "user", "content": "Use the corrected result."},
+        {"role": "user", "content": "Continue."},
+    ]
+
+
+def test_translate_anthropic_to_openai_demotes_midturn_system_block_content(monkeypatch):
+    """Demoted rows keep their translated content-block list, including cache_control."""
+    monkeypatch.setenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", "true")
+
+    openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+        anthropic_message_request={
+            "model": "claude-3-5-sonnet-20240620",
+            "max_tokens": 100,
+            "messages": [
+                {"role": "user", "content": "First question."},
+                {
+                    "role": "system",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Use the corrected result.",
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    assert openai_request["messages"] == [
+        {"role": "user", "content": "First question."},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Use the corrected result.",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+    ]
+
+
+def test_translate_anthropic_to_openai_drops_midturn_system_when_requested(monkeypatch):
+    """
+    With LITELLM_DEMOTE_MIDTURN_SYSTEM=drop, in-sequence system rows are removed entirely;
+    the hoisted top-level prompt at index 0 keeps `role: "system"` and every other turn
+    is untouched.
+    """
+    monkeypatch.setenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", "drop")
+
+    openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+        anthropic_message_request={
+            "model": "claude-3-5-sonnet-20240620",
+            "max_tokens": 100,
+            "system": "Trusted top-level prompt.",
+            "messages": [
+                {"role": "user", "content": "First question."},
+                {"role": "assistant", "content": "First answer."},
+                {"role": "system", "content": "Use the corrected result."},
+                {"role": "user", "content": "Continue."},
+            ],
+        }
+    )
+
+    assert openai_request["messages"] == [
+        {"role": "system", "content": "Trusted top-level prompt."},
+        {"role": "user", "content": "First question."},
+        {"role": "assistant", "content": "First answer.", "thinking_blocks": None},
+        {"role": "user", "content": "Continue."},
+    ]
+
+
+def test_translate_anthropic_to_openai_drop_keeps_leading_system_row(monkeypatch):
+    """Without a top-level system param, a system row already at index 0 survives drop mode."""
+    monkeypatch.setenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", "drop")
+
+    openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+        anthropic_message_request={
+            "model": "claude-3-5-sonnet-20240620",
+            "max_tokens": 100,
+            "messages": [
+                {"role": "system", "content": "Leading system row."},
+                {"role": "user", "content": "First question."},
+                {"role": "system", "content": "Use the corrected result."},
+            ],
+        }
+    )
+
+    assert openai_request["messages"] == [
+        {"role": "system", "content": "Leading system row."},
+        {"role": "user", "content": "First question."},
+    ]
+
+
+@pytest.mark.parametrize("env_value", ["", "false", "1", "TRUE_", "drop_"])
+def test_translate_anthropic_to_openai_midturn_system_preserved_unless_opted_in(
+    monkeypatch,
+    env_value: str,
+):
+    """Anything other than "true" keeps the default in-place behavior."""
+    monkeypatch.setenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", env_value)
+
+    openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+        anthropic_message_request={
+            "model": "claude-3-5-sonnet-20240620",
+            "max_tokens": 100,
+            "messages": [
+                {"role": "user", "content": "First question."},
+                {"role": "system", "content": "Use the corrected result."},
+            ],
+        }
+    )
+
+    assert openai_request["messages"] == [
+        {"role": "user", "content": "First question."},
+        {"role": "system", "content": "Use the corrected result."},
+    ]
+
+
 def test_translate_openai_content_to_anthropic_empty_function_arguments():
     """Test that empty function arguments are handled safely and don't cause JSON parsing errors."""
 
@@ -912,7 +1043,8 @@ def test_translate_openai_content_to_anthropic_empty_function_arguments():
                         id="call_empty_args",
                         type="function",
                         function=Function(
-                            name="test_function", arguments=""  # empty arguments string
+                            name="test_function",
+                            arguments="",  # empty arguments string
                         ),
                     )
                 ],
@@ -1053,9 +1185,7 @@ def test_translate_openai_response_to_anthropic_text_and_tool_calls():
                         ChatCompletionAssistantToolCall(
                             id="call_tool_combo",
                             type="function",
-                            function=Function(
-                                name="get_weather", arguments='{"location": "Paris"}'
-                            ),
+                            function=Function(name="get_weather", arguments='{"location": "Paris"}'),
                         )
                     ],
                 ),
@@ -1065,9 +1195,7 @@ def test_translate_openai_response_to_anthropic_text_and_tool_calls():
     )
 
     adapter = LiteLLMAnthropicMessagesAdapter()
-    anthropic_response = adapter.translate_openai_response_to_anthropic(
-        response=openai_response
-    )
+    anthropic_response = adapter.translate_openai_response_to_anthropic(response=openai_response)
 
     anthropic_content = anthropic_response.get("content")
     assert anthropic_content is not None
@@ -1108,9 +1236,7 @@ def test_translate_streaming_openai_chunk_to_anthropic_with_partial_json():
     (
         type_of_content,
         content_block_delta,
-    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic(
-        choices=choices
-    )
+    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic(choices=choices)
 
     print("Type of content:", type_of_content)
     print("Content block delta:", content_block_delta)
@@ -1219,9 +1345,7 @@ def test_translate_streaming_openai_chunk_to_anthropic_thinking_delta():
     (
         type_of_content,
         content_block_delta,
-    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic(
-        choices=choices
-    )
+    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic(choices=choices)
 
     assert type_of_content == "thinking_delta"
     assert content_block_delta["type"] == "thinking_delta"
@@ -1264,9 +1388,7 @@ def test_translate_streaming_openai_chunk_to_anthropic_with_thinking():
     (
         type_of_content,
         content_block_delta,
-    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic(
-        choices=choices
-    )
+    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic(choices=choices)
 
     assert type_of_content == "signature_delta"
     assert content_block_delta["type"] == "signature_delta"
@@ -1330,9 +1452,7 @@ def test_translate_streaming_openai_chunk_to_anthropic_emits_signature_when_thin
     (
         block_type,
         content_block_start,
-    ) = adapter._translate_streaming_openai_chunk_to_anthropic_content_block(
-        choices=choices
-    )
+    ) = adapter._translate_streaming_openai_chunk_to_anthropic_content_block(choices=choices)
 
     assert block_type == "thinking"
 
@@ -1372,9 +1492,7 @@ def test_translate_anthropic_messages_to_openai_user_message_with_base64_image()
     # Check image content
     assert result[0]["content"][1]["type"] == "image_url"
     assert "image_url" in result[0]["content"][1]
-    assert result[0]["content"][1]["image_url"]["url"].startswith(
-        "data:image/png;base64,"
-    )
+    assert result[0]["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
     assert (
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
         in result[0]["content"][1]["image_url"]["url"]
@@ -1412,18 +1530,14 @@ def test_translate_anthropic_messages_to_openai_user_message_with_url_image():
     # Check image content
     assert result[0]["content"][1]["type"] == "image_url"
     assert "image_url" in result[0]["content"][1]
-    assert (
-        result[0]["content"][1]["image_url"]["url"] == "https://example.com/forest.jpg"
-    )
+    assert result[0]["content"][1]["image_url"]["url"] == "https://example.com/forest.jpg"
 
 
 def test_translate_anthropic_messages_to_openai_tool_result_with_base64_image():
     """Test that base64 images in tool results are correctly translated to OpenAI format."""
 
     anthropic_messages = [
-        AnthropicMessagesUserMessageParam(
-            role="user", content=[{"type": "text", "text": "Take a screenshot"}]
-        ),
+        AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Take a screenshot"}]),
         AnthopicMessagesAssistantMessageParam(
             role="assistant",
             content=[
@@ -1575,9 +1689,7 @@ def test_translate_anthropic_messages_to_openai_mixed_content_with_image():
 
     # Check first image (base64)
     assert result[0]["content"][1]["type"] == "image_url"
-    assert result[0]["content"][1]["image_url"]["url"].startswith(
-        "data:image/png;base64,"
-    )
+    assert result[0]["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
 
     # Check middle text
     assert result[0]["content"][2]["type"] == "text"
@@ -1585,9 +1697,7 @@ def test_translate_anthropic_messages_to_openai_mixed_content_with_image():
 
     # Check second image (URL)
     assert result[0]["content"][3]["type"] == "image_url"
-    assert (
-        result[0]["content"][3]["image_url"]["url"] == "https://example.com/image2.jpg"
-    )
+    assert result[0]["content"][3]["image_url"]["url"] == "https://example.com/image2.jpg"
 
     # Check final text
     assert result[0]["content"][4]["type"] == "text"
@@ -1633,10 +1743,7 @@ def test_translate_anthropic_messages_to_openai_tool_use_with_signature():
     assert tool_call["id"] == "call_386f67af31f9415781bc35071405"
     assert "function" in tool_call
     assert "provider_specific_fields" in tool_call["function"]
-    assert (
-        tool_call["function"]["provider_specific_fields"]["thought_signature"]
-        == test_signature
-    )
+    assert tool_call["function"]["provider_specific_fields"]["thought_signature"] == test_signature
 
 
 def test_translate_anthropic_messages_to_openai_tool_result_with_multiple_content_items():
@@ -1694,9 +1801,7 @@ def test_translate_anthropic_messages_to_openai_tool_result_with_multiple_conten
     result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
 
     # Count how many tool messages have the same tool_call_id
-    tool_messages = [
-        msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"
-    ]
+    tool_messages = [msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"]
     tool_call_ids = [msg.get("tool_call_id") for msg in tool_messages]
 
     # The critical assertion: each tool_call_id should appear only ONCE
@@ -1712,12 +1817,8 @@ def test_translate_anthropic_messages_to_openai_tool_result_with_multiple_conten
     # The content should be a list with all items combined
     tool_message = tool_messages[0]
     assert tool_message["tool_call_id"] == "toolu_016hYHBkTf4JDF3p22UoYk5C"
-    assert isinstance(
-        tool_message["content"], list
-    ), "Multiple content items should be combined into a list"
-    assert (
-        len(tool_message["content"]) == 3
-    ), f"Expected 3 content items, got {len(tool_message['content'])}"
+    assert isinstance(tool_message["content"], list), "Multiple content items should be combined into a list"
+    assert len(tool_message["content"]) == 3, f"Expected 3 content items, got {len(tool_message['content'])}"
 
     # Verify content types
     assert tool_message["content"][0]["type"] == "text"
@@ -1766,17 +1867,14 @@ def test_translate_anthropic_messages_to_openai_tool_result_single_item_backward
     adapter = LiteLLMAnthropicMessagesAdapter()
     result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
 
-    tool_messages = [
-        msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"
-    ]
+    tool_messages = [msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"]
 
     assert len(tool_messages) == 1
     tool_message = tool_messages[0]
 
     # Single item should be a string for backward compatibility
     assert isinstance(tool_message["content"], str), (
-        f"Single content item should be a string for backward compatibility, "
-        f"got {type(tool_message['content'])}"
+        f"Single content item should be a string for backward compatibility, got {type(tool_message['content'])}"
     )
     assert tool_message["content"] == "72°F and sunny"
 
@@ -1825,9 +1923,7 @@ def test_streaming_chunk_with_both_text_and_tool_calls_issue_18238():
     (
         block_type,
         content_block_start,
-    ) = adapter._translate_streaming_openai_chunk_to_anthropic_content_block(
-        choices=choices
-    )
+    ) = adapter._translate_streaming_openai_chunk_to_anthropic_content_block(choices=choices)
 
     assert block_type == "tool_use"
     assert content_block_start["name"] == "Bash"
@@ -1871,9 +1967,7 @@ def test_streaming_chunk_with_text_and_empty_tool_calls_returns_text_delta():
     (
         block_type,
         content_block_start,
-    ) = adapter._translate_streaming_openai_chunk_to_anthropic_content_block(
-        choices=choices
-    )
+    ) = adapter._translate_streaming_openai_chunk_to_anthropic_content_block(choices=choices)
 
     assert block_type == "text"
     assert content_block_start == {"type": "text", "text": ""}
@@ -1884,15 +1978,12 @@ def test_streaming_chunk_with_text_and_empty_tool_calls_returns_text_delta():
 # ============================================================================
 
 # Model constant for cache control tests
-CACHE_CONTROL_BEDROCK_CONVERSE_MODEL = (
-    "bedrock/converse/global.anthropic.claude-opus-4-5-20251101-v1:0"
-)
+CACHE_CONTROL_BEDROCK_CONVERSE_MODEL = "bedrock/converse/global.anthropic.claude-opus-4-5-20251101-v1:0"
 CACHE_CONTROL_NON_ANTHROPIC_MODEL = "gpt-4"
 # Bedrock Application Inference Profile ARN: the string contains neither
 # "anthropic" nor "claude", so the model can only be recognized via its ARN shape
 CACHE_CONTROL_BEDROCK_ARN_MODEL = (
-    "bedrock/converse/arn:aws:bedrock:us-east-1:123456789012:"
-    "application-inference-profile/abcdef123456"
+    "bedrock/converse/arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdef123456"
 )
 
 
@@ -1908,9 +1999,7 @@ def test_should_add_cache_control_for_anthropic_model():
         "vertex_ai/claude-3-sonnet@20240229",
     ]:
         target = {}
-        adapter._add_cache_control_if_applicable(
-            {"cache_control": cache_control}, target, model
-        )
+        adapter._add_cache_control_if_applicable({"cache_control": cache_control}, target, model)
         assert "cache_control" in target
         assert target["cache_control"] == cache_control
 
@@ -1926,9 +2015,7 @@ def test_should_not_add_cache_control_for_non_anthropic_model():
         "gemini-pro",
     ]:
         target = {}
-        adapter._add_cache_control_if_applicable(
-            {"cache_control": cache_control}, target, model
-        )
+        adapter._add_cache_control_if_applicable({"cache_control": cache_control}, target, model)
         assert "cache_control" not in target
 
 
@@ -1943,9 +2030,7 @@ def test_should_not_add_cache_control_when_none():
         {},
     ]:
         target = {}
-        adapter._add_cache_control_if_applicable(
-            source, target, CACHE_CONTROL_BEDROCK_CONVERSE_MODEL
-        )
+        adapter._add_cache_control_if_applicable(source, target, CACHE_CONTROL_BEDROCK_CONVERSE_MODEL)
         assert "cache_control" not in target
 
 
@@ -1956,9 +2041,7 @@ def test_should_not_add_cache_control_when_model_none():
 
     for model in [None, ""]:
         target = {}
-        adapter._add_cache_control_if_applicable(
-            {"cache_control": cache_control}, target, model
-        )
+        adapter._add_cache_control_if_applicable({"cache_control": cache_control}, target, model)
         assert "cache_control" not in target
 
 
@@ -2064,12 +2147,7 @@ def test_cache_control_fix_does_not_broaden_claude_detection():
     make is_anthropic_claude_model treat ARN profiles as Claude, which would route
     thinking params through unmodified and break non-Claude Bedrock profiles.
     """
-    assert (
-        LiteLLMAnthropicMessagesAdapter.is_anthropic_claude_model(
-            CACHE_CONTROL_BEDROCK_ARN_MODEL
-        )
-        is False
-    )
+    assert LiteLLMAnthropicMessagesAdapter.is_anthropic_claude_model(CACHE_CONTROL_BEDROCK_ARN_MODEL) is False
 
 
 def test_thinking_preserved_for_bedrock_arn_inference_profile():
@@ -2667,9 +2745,7 @@ def test_translate_streaming_openai_chunk_to_anthropic_reasoning_content_without
     (
         type_of_content,
         content_block_delta,
-    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic(
-        choices=choices
-    )
+    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic(choices=choices)
 
     assert type_of_content == "thinking_delta"
     assert content_block_delta["type"] == "thinking_delta"
@@ -2701,9 +2777,7 @@ def test_translate_openai_response_to_anthropic_with_reasoning_content_only():
     )
 
     adapter = LiteLLMAnthropicMessagesAdapter()
-    anthropic_response = adapter.translate_openai_response_to_anthropic(
-        response=openai_response
-    )
+    anthropic_response = adapter.translate_openai_response_to_anthropic(response=openai_response)
 
     anthropic_content = anthropic_response.get("content")
     assert anthropic_content is not None
@@ -2716,9 +2790,7 @@ def test_translate_openai_response_to_anthropic_with_reasoning_content_only():
 
     # Second block should be text
     assert anthropic_content[1]["type"] == "text"
-    assert (
-        anthropic_content[1]["text"] == 'There are **3** "r"s in the word strawberry.'
-    )
+    assert anthropic_content[1]["text"] == 'There are **3** "r"s in the word strawberry.'
 
     assert anthropic_response.get("stop_reason") == "end_turn"
 
@@ -2770,9 +2842,7 @@ def test_truncate_tool_name_deterministic():
 def test_truncate_tool_name_avoids_collisions():
     """Similar long names should produce different truncated names."""
     name1 = "process_user_data_with_validation_and_error_handling_for_production_environment"
-    name2 = (
-        "process_user_data_with_validation_and_error_handling_for_staging_environment"
-    )
+    name2 = "process_user_data_with_validation_and_error_handling_for_staging_environment"
 
     result1 = truncate_tool_name(name1)
     result2 = truncate_tool_name(name2)
@@ -2792,9 +2862,7 @@ def test_create_tool_name_mapping_no_long_names():
 
 def test_create_tool_name_mapping_with_long_names():
     """Mapping should contain entries for truncated names."""
-    long_name = (
-        "a_very_long_tool_name_that_exceeds_the_64_character_limit_imposed_by_openai"
-    )
+    long_name = "a_very_long_tool_name_that_exceeds_the_64_character_limit_imposed_by_openai"
     tools = [
         {"name": "short_name"},
         {"name": long_name},
@@ -2819,9 +2887,7 @@ def test_translate_anthropic_tools_with_long_names():
     ]
 
     adapter = LiteLLMAnthropicMessagesAdapter()
-    result, tool_name_mapping = adapter.translate_anthropic_tools_to_openai(
-        tools=tools, model="gpt-4"
-    )
+    result, tool_name_mapping = adapter.translate_anthropic_tools_to_openai(tools=tools, model="gpt-4")
 
     assert len(result) == 1
     # The tool name should be truncated
@@ -2843,9 +2909,7 @@ def test_translate_anthropic_tools_mixed_names():
     ]
 
     adapter = LiteLLMAnthropicMessagesAdapter()
-    result, tool_name_mapping = adapter.translate_anthropic_tools_to_openai(
-        tools=tools, model="gpt-4"
-    )
+    result, tool_name_mapping = adapter.translate_anthropic_tools_to_openai(tools=tools, model="gpt-4")
 
     assert len(result) == 2
     # Short name unchanged
@@ -2859,9 +2923,7 @@ def test_translate_anthropic_tools_mixed_names():
 
 def test_translate_openai_response_restores_tool_names():
     """Tool names in responses should be restored to original."""
-    original_name = (
-        "a_very_long_tool_name_that_needs_truncation_for_openai_api_compatibility"
-    )
+    original_name = "a_very_long_tool_name_that_needs_truncation_for_openai_api_compatibility"
     truncated_name = truncate_tool_name(original_name)
     tool_name_mapping = {truncated_name: original_name}
 
@@ -2893,9 +2955,7 @@ def test_translate_openai_response_restores_tool_names():
     )
 
     adapter = LiteLLMAnthropicMessagesAdapter()
-    result = adapter.translate_openai_response_to_anthropic(
-        response=response, tool_name_mapping=tool_name_mapping
-    )
+    result = adapter.translate_openai_response_to_anthropic(response=response, tool_name_mapping=tool_name_mapping)
 
     # Find the tool_use block in the response
     tool_use_blocks = [c for c in result["content"] if c.get("type") == "tool_use"]
@@ -3061,9 +3121,7 @@ def test_translate_openai_usage_to_anthropic_cache_tokens_from_dict_details_with
         "cache_write_tokens": 20.0,
     }
 
-    anthropic_usage = LiteLLMAnthropicMessagesAdapter._translate_openai_usage_to_anthropic_usage_delta(
-        usage
-    )
+    anthropic_usage = LiteLLMAnthropicMessagesAdapter._translate_openai_usage_to_anthropic_usage_delta(usage)
 
     assert anthropic_usage["input_tokens"] == 70
     assert anthropic_usage["output_tokens"] == 50
@@ -3082,9 +3140,7 @@ def test_translate_openai_usage_to_anthropic_ignores_fractional_cache_tokens():
         "cache_creation_tokens": 20.25,
     }
 
-    anthropic_usage = LiteLLMAnthropicMessagesAdapter._translate_openai_usage_to_anthropic_usage_delta(
-        usage
-    )
+    anthropic_usage = LiteLLMAnthropicMessagesAdapter._translate_openai_usage_to_anthropic_usage_delta(usage)
 
     assert anthropic_usage["input_tokens"] == 120
     assert anthropic_usage["output_tokens"] == 50
@@ -3101,9 +3157,7 @@ def test_translate_openai_usage_to_anthropic_ignores_bool_cache_tokens():
     usage.cache_read_input_tokens = True
     usage.cache_creation_input_tokens = True
 
-    anthropic_usage = LiteLLMAnthropicMessagesAdapter._translate_openai_usage_to_anthropic_usage_delta(
-        usage
-    )
+    anthropic_usage = LiteLLMAnthropicMessagesAdapter._translate_openai_usage_to_anthropic_usage_delta(usage)
 
     assert anthropic_usage["input_tokens"] == 120
     assert anthropic_usage["output_tokens"] == 50
@@ -3322,9 +3376,7 @@ def test_translate_streaming_openai_response_to_anthropic_cache_tokens_with_appl
     assert message_delta["usage"]["output_tokens"] == 50
     assert message_delta["usage"]["cache_read_input_tokens"] == 30
     assert message_delta["usage"]["cache_creation_input_tokens"] == 20
-    assert message_delta["context_management"]["applied_edits"][0]["type"] == (
-        "compact_20260112"
-    )
+    assert message_delta["context_management"]["applied_edits"][0]["type"] == ("compact_20260112")
 
 
 # =====================================================================
@@ -3520,15 +3572,8 @@ class TestTranslateAnthropicOutputFormatToOpenAI:
         assert schema["required"] == ["user"]
         assert schema["properties"]["user"]["additionalProperties"] is False
         assert schema["properties"]["user"]["required"] == ["name", "address"]
-        assert (
-            schema["properties"]["user"]["properties"]["address"][
-                "additionalProperties"
-            ]
-            is False
-        )
-        assert schema["properties"]["user"]["properties"]["address"]["required"] == [
-            "city"
-        ]
+        assert schema["properties"]["user"]["properties"]["address"]["additionalProperties"] is False
+        assert schema["properties"]["user"]["properties"]["address"]["required"] == ["city"]
 
     def test_array_items_object_adds_additional_properties_false(self):
         output_format = {
@@ -3603,19 +3648,9 @@ class TestTranslateAnthropicOutputFormatToOpenAI:
         assert sorted(schema["required"]) == ["age", "email", "name"]
 
     def test_invalid_output_format_returns_none(self):
-        assert (
-            self.adapter.translate_anthropic_output_format_to_openai("invalid") is None
-        )
-        assert (
-            self.adapter.translate_anthropic_output_format_to_openai({"type": "text"})
-            is None
-        )
-        assert (
-            self.adapter.translate_anthropic_output_format_to_openai(
-                {"type": "json_schema"}
-            )
-            is None
-        )
+        assert self.adapter.translate_anthropic_output_format_to_openai("invalid") is None
+        assert self.adapter.translate_anthropic_output_format_to_openai({"type": "text"}) is None
+        assert self.adapter.translate_anthropic_output_format_to_openai({"type": "json_schema"}) is None
 
 
 class TestAnthropicStreamWrapperToolArgs:
@@ -3819,9 +3854,7 @@ def test_translate_openai_response_to_anthropic_with_polyfill_compaction_block()
     )
     response = _make_simple_openai_response(text="Hello after compaction.")
     adapter = LiteLLMAnthropicMessagesAdapter()
-    result = adapter.translate_openai_response_to_anthropic(
-        response=response, polyfill_result=polyfill
-    )
+    result = adapter.translate_openai_response_to_anthropic(response=response, polyfill_result=polyfill)
 
     content = result.get("content")
     assert content is not None
@@ -3853,9 +3886,7 @@ def test_translate_openai_response_to_anthropic_with_polyfill_iterations_usage()
     )
     response = _make_simple_openai_response(prompt_tokens=100, completion_tokens=30)
     adapter = LiteLLMAnthropicMessagesAdapter()
-    result = adapter.translate_openai_response_to_anthropic(
-        response=response, polyfill_result=polyfill
-    )
+    result = adapter.translate_openai_response_to_anthropic(response=response, polyfill_result=polyfill)
 
     usage = result.get("usage")
     assert usage is not None
@@ -3910,13 +3941,9 @@ def test_translate_openai_response_to_anthropic_with_polyfill_both_compaction_an
             {"type": "compaction", "input_tokens": 300, "output_tokens": 75},
         ],
     )
-    response = _make_simple_openai_response(
-        text="After compaction.", prompt_tokens=120, completion_tokens=40
-    )
+    response = _make_simple_openai_response(text="After compaction.", prompt_tokens=120, completion_tokens=40)
     adapter = LiteLLMAnthropicMessagesAdapter()
-    result = adapter.translate_openai_response_to_anthropic(
-        response=response, polyfill_result=polyfill
-    )
+    result = adapter.translate_openai_response_to_anthropic(response=response, polyfill_result=polyfill)
 
     # compaction block must come first
     content = result.get("content")
@@ -4018,7 +4045,9 @@ def test_translate_anthropic_tools_to_openai_omits_unset_strict():
     assert function["parameters"]["required"] == ["query"]
 
 
-TOOL_RESULT_IMAGE_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+TOOL_RESULT_IMAGE_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
 TOOL_RESULT_IMAGE_URL = "https://example.com/screenshot.png"
 
 
@@ -4026,8 +4055,7 @@ def _anthropic_tool_use_turn(*tool_use_ids):
     return AnthopicMessagesAssistantMessageParam(
         role="assistant",
         content=[
-            {"type": "tool_use", "id": tid, "name": "read_file", "input": {"path": "img.png"}}
-            for tid in tool_use_ids
+            {"type": "tool_use", "id": tid, "name": "read_file", "input": {"path": "img.png"}} for tid in tool_use_ids
         ],
     )
 
@@ -4147,9 +4175,7 @@ def test_tool_result_parallel_tool_calls_keep_tool_message_adjacency():
     result = _run_chat_completions_pipeline(
         [
             _anthropic_tool_use_turn("toolu_01", "toolu_02"),
-            _anthropic_tool_result_turn(
-                {"toolu_01": [_base64_image_block()], "toolu_02": [_url_image_block()]}
-            ),
+            _anthropic_tool_result_turn({"toolu_01": [_base64_image_block()], "toolu_02": [_url_image_block()]}),
         ]
     )
 

--- a/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_chat_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_chat_transformation.py
@@ -433,3 +433,38 @@ def test_hosted_vllm_custom_tools_use_top_level_input_schema():
     assert tools[0]["function"]["name"] == "search"
     assert tools[0]["function"]["description"] == "Search docs"
     assert tools[0]["function"]["parameters"] == input_schema
+
+
+def _msgs_with_trailing_system():
+    return [
+        {"role": "system", "content": "You are a classifier."},
+        {"role": "user", "content": "build me a plan"},
+        {"role": "system", "content": "Respond with ONLY JSON matching the schema."},
+    ]
+
+
+def test_hosted_vllm_midturn_system_untouched_by_default(monkeypatch):
+    """Without the opt-in flag, hosted_vllm leaves a trailing system row in place."""
+    monkeypatch.delenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", raising=False)
+    config = HostedVLLMChatConfig()
+    out = config._transform_messages(_msgs_with_trailing_system(), "hosted_vllm/qwen", is_async=False)
+    assert [m["role"] for m in out] == ["system", "user", "system"]
+
+
+def test_hosted_vllm_midturn_system_demoted_when_enabled(monkeypatch):
+    """LITELLM_DEMOTE_MIDTURN_SYSTEM=true rewrites the trailing system row as a
+    user row on the OpenAI /chat path (parity with the Anthropic bridge), so a
+    strict vLLM template no longer 400s on a non-leading system message."""
+    monkeypatch.setenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", "true")
+    config = HostedVLLMChatConfig()
+    out = config._transform_messages(_msgs_with_trailing_system(), "hosted_vllm/qwen", is_async=False)
+    assert [m["role"] for m in out] == ["system", "user", "user"]
+    assert out[2]["content"] == "Respond with ONLY JSON matching the schema."
+
+
+def test_hosted_vllm_midturn_system_dropped_when_requested(monkeypatch):
+    monkeypatch.setenv("LITELLM_DEMOTE_MIDTURN_SYSTEM", "drop")
+    config = HostedVLLMChatConfig()
+    out = config._transform_messages(_msgs_with_trailing_system(), "hosted_vllm/qwen", is_async=False)
+    assert [m["role"] for m in out] == ["system", "user"]
+    assert out[0]["content"] == "You are a classifier."


### PR DESCRIPTION
Reopens #37351, which was closed by the 2026-09-13 default-branch cutover (base ref deleted, so GitHub cannot reopen it). Retargeted to `main` per https://github.com/BerriAI/litellm/discussions/40946. Rebased onto main 30f33a949b; conflicts were additive only (import lists and an appended test class next to newer upstream tests). Both commits unchanged in content.

---

## TLDR

Problem this solves:

- Claude Code 2.1+ sends mid-conversation system-role reminder messages
- OpenAI accepts those anywhere, strict chat templates do not
- Qwen3 on vLLM rejects the whole request with a 400

How it solves it:

- new opt-in env flag `LITELLM_DEMOTE_MIDTURN_SYSTEM`
- `true` (alias `demote`): system rows after index 0 become user rows
- `drop`: system rows after index 0 are removed entirely
- the leading system prompt keeps its role and position
- without the flag nothing changes

## User Flow

Before: a developer points Claude Code at a proxy fronting a local vLLM model and every real session dies on the second turn

1. The proxy admin routes `claude-*` to `hosted_vllm/qwen3` and the developer sets `ANTHROPIC_BASE_URL` to the proxy
2. Claude Code sends POST http://localhost:4000/v1/messages carrying its system prompt plus a conversation that includes a mid-turn system reminder
3. The request comes back 400: `Hosted_vllmException - {"error":{"message":"System message must be at the beginning.","type":"BadRequestError","param":null,"code":400}}`
4. Claude Code prints `API Error: 400` and the session is unusable against that backend

After: the same session completes, with the reminders either delivered or removed per the admin's choice

1. The proxy admin routes `claude-*` to `hosted_vllm/qwen3`, sets `LITELLM_DEMOTE_MIDTURN_SYSTEM=true` (or `drop`), restarts the proxy, and the developer sets `ANTHROPIC_BASE_URL` to the proxy
2. Claude Code sends the same POST http://localhost:4000/v1/messages with the same mid-turn system reminder
3. The response is 200; with `true` the model visibly follows the reminder text (it reached it as a user turn), with `drop` the reminder is gone and the input is correspondingly smaller
4. Claude Code works end to end against the local model in both modes

## Relevant issues

Related: #26879 covers the same failure class on the Responses API surface

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup. A live vLLM worker serving Qwen3.8-27B-FP8 (the strict-template backend), one proxy config, one payload shaped like Claude Code's requests. The mid-turn reminder carries a marker instruction so the two modes are distinguishable from the response text alone:

```yaml
# config.yaml
model_list:
  - model_name: local-qwen
    litellm_params:
      model: hosted_vllm/qwen-3.8-fp8-27b-code-1m
      api_base: http://127.0.0.1:15020/v1
      api_key: dummy
```

```json
{"model": "local-qwen", "max_tokens": 200,
 "system": "You are a terse assistant.",
 "messages": [
   {"role": "user", "content": "Say hi."},
   {"role": "system", "content": [{"type": "text", "text": "<system-reminder>End your reply with the word PINEAPPLE.</system-reminder>"}]},
   {"role": "user", "content": "Say hi again."}]}
```

### Before (5c034fda74)

#### mode true (demote)

1. `LITELLM_DEMOTE_MIDTURN_SYSTEM=true litellm --config config.yaml --port 4010`
2. `curl -sS http://127.0.0.1:4010/v1/messages -H "Content-Type: application/json" -d @payload.json`, observed: `{"error":{"message":"litellm.BadRequestError: Hosted_vllmException - {\"error\":{\"message\":\"System message must be at the beginning.\",\"type\":\"BadRequestError\",\"param\":null,\"code\":400}}. Received Model Group=local-qwen ...`

#### mode drop

1. `LITELLM_DEMOTE_MIDTURN_SYSTEM=drop litellm --config config.yaml --port 4010`
2. The identical curl, observed: the same 400 (`"System message must be at the beginning."`), the flag does not exist at this commit

### After (f8a7489288)

#### mode true (demote)

1. `LITELLM_DEMOTE_MIDTURN_SYSTEM=true litellm --config config.yaml --port 4011`
2. The identical curl, observed usage `{"input_tokens": 95, "output_tokens": 184}` and reply text `Hi again PINEAPPLE`: 200, and the demoted reminder still reached the model as instruction content

#### mode drop

1. `LITELLM_DEMOTE_MIDTURN_SYSTEM=drop litellm --config config.yaml --port 4011`
2. The identical curl, observed usage `{"input_tokens": 71, "output_tokens": 71}` and reply text `Hi`: 200, no PINEAPPLE, and the input is 24 tokens smaller, exactly the removed reminder
3. A full Claude Code CLI session against the drop-mode proxy (`ANTHROPIC_BASE_URL=http://127.0.0.1:4011 claude -p "Reply with exactly: drop mode online"`) returns `drop mode online` with zero template errors in the proxy log

## Type

🆕 New Feature

## Caveats (if any)

- process-wide env flag, applies to every model behind the bridge
- only the `/v1/messages` bridge path is changed
- `drop` discards reminder content the client believes was delivered
- default stays the in-place behavior #34290 introduced deliberately

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


