### PR TITLE
fix(proxy): namespace debug environment variables

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -706,7 +706,7 @@ class ProxyInitializationHelpers:
     is_flag=True,
     type=bool,
     help="To debug the input",
-    envvar="DEBUG",
+    envvar="LITELLM_DEBUG",
 )
 @click.option(
     "--detailed_debug",
@@ -714,7 +714,7 @@ class ProxyInitializationHelpers:
     is_flag=True,
     type=bool,
     help="To view detailed debug logs",
-    envvar="DETAILED_DEBUG",
+    envvar="LITELLM_DETAILED_DEBUG",
 )
 @click.option(
     "--use_queue",

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -19,6 +20,28 @@ from uvicorn.config import LOOP_FACTORIES
 from uvicorn.importer import import_from_string
 
 from litellm.proxy.proxy_cli import ProxyInitializationHelpers, run_server
+
+
+@pytest.mark.parametrize(
+    ("environment", "arguments", "expected_debug", "expected_detailed_debug"),
+    (
+        ({"DEBUG": "release"}, (), False, False),
+        ({"LITELLM_DEBUG": "1"}, (), True, False),
+        ({"DETAILED_DEBUG": "release"}, (), False, False),
+        ({"LITELLM_DETAILED_DEBUG": "1"}, (), False, True),
+        ({}, ("--debug", "--detailed_debug"), True, True),
+    ),
+)
+def test_debug_options_use_namespaced_environment_variables(
+    environment: Mapping[str, str],
+    arguments: tuple[str, ...],
+    expected_debug: bool,
+    expected_detailed_debug: bool,
+) -> None:
+    with patch.dict(os.environ, environment, clear=True):
+        with run_server.make_context("litellm", list(arguments)) as context:
+            assert context.params["debug"] is expected_debug
+            assert context.params["detailed_debug"] is expected_detailed_debug
 
 
 @pytest.mark.xdist_group("proxy_cli")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Generic `DEBUG` values can break proxy startup
- Common environment names can enable debugging accidentally

How it solves it:

- Binds `--debug` to `LITELLM_DEBUG`
- Binds detailed logs to `LITELLM_DETAILED_DEBUG`

PR #38793 carried the same change against `litellm_internal_staging` and closed unmerged. The repository now defaults to `main`, so this PR is based on current `main`

## User Flow

Before: a proxy operator inheriting `DEBUG=release` cannot start LiteLLM

1. They run `DEBUG=release litellm --local --skip_server_startup`
2. The CLI exits with `Invalid value for '--debug': 'release' is not a valid boolean`

After: the same unrelated environment value no longer affects LiteLLM

1. They run `DEBUG=release litellm --local --skip_server_startup`
2. The CLI completes setup and reports that server startup was skipped

## Relevant issues

Fixes #38781

## Affected release

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

### Before (30f33a94)

1. Run `git show 30f33a94:litellm/proxy/proxy_cli.py | DEBUG=release LITELLM_MODE=PRODUCTION LITELLM_LOCAL_MODEL_COST_MAP=True uv run --no-sync python - --local --skip_server_startup`
2. Observe exit code 2 and `Invalid value for '--debug': 'release' is not a valid boolean`

### After (81cd9240)

1. Run `DEBUG=release LITELLM_MODE=PRODUCTION LITELLM_LOCAL_MODEL_COST_MAP=True PYTHONPATH=. uv run --no-sync python litellm/proxy/proxy_cli.py --local --skip_server_startup`
2. Observe exit code 0 and `LiteLLM: Setup complete. Skipping server startup as requested.`

## Type

Bug Fix

## Caveats (if any)

### Severe

- Bare `DEBUG` users must move to `LITELLM_DEBUG` or `--debug`
- Bare detailed-debug users must move to the namespaced setting or flag

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
