### PR TITLE
fix(ui): decouple semantic caching from the Redis Type dropdown in Cache Settings

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/RedisTypeSelector.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/RedisTypeSelector.tsx
@@ -11,7 +11,6 @@ const REDIS_TYPE_LABELS: Readonly<Record<string, string>> = {
   node: "Node (Single Instance)",
   cluster: "Cluster",
   sentinel: "Sentinel",
-  semantic: "Semantic",
 };
 
 const RedisTypeSelector: React.FC<RedisTypeSelectorProps> = ({ redisType, redisTypeDescriptions, onTypeChange }) => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsFields.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsFields.ts
@@ -13,7 +13,7 @@ export interface CacheFieldOption {
   readonly label: string;
 }
 
-export type RedisType = "node" | "cluster" | "sentinel" | "semantic";
+export type RedisType = "node" | "cluster" | "sentinel";
 
 export type CacheSection = "connection" | "cluster" | "sentinel" | "semantic" | "ssl" | "cacheManagement" | "gcp";
 
@@ -38,13 +38,12 @@ export interface CacheField {
   readonly secret?: boolean;
 }
 
-export const REDIS_TYPES: readonly RedisType[] = ["node", "cluster", "sentinel", "semantic"];
+export const REDIS_TYPES: readonly RedisType[] = ["node", "cluster", "sentinel"];
 
 export const REDIS_TYPE_DESCRIPTIONS: Readonly<Record<RedisType, string>> = {
   node: "Standard Redis node/single instance",
   cluster: "Redis Cluster mode for high availability and horizontal scaling",
   sentinel: "Redis Sentinel mode for high availability with automatic failover",
-  semantic: "Semantic caching that reuses responses for similar prompts",
 };
 
 const isBlank = (value: unknown): boolean => value === undefined || value === null || String(value).trim() === "";
@@ -181,7 +180,7 @@ export const CACHE_FIELDS: readonly CacheField[] = [
     type: "float",
     section: "semantic",
     helpText: "Similarity threshold for semantic cache",
-    redisType: "semantic",
+    redisType: null,
     defaultValue: 0.8,
     rules: [numberRule],
   },
@@ -191,7 +190,7 @@ export const CACHE_FIELDS: readonly CacheField[] = [
     type: "model-select",
     section: "semantic",
     helpText: "Embedding model for semantic cache",
-    redisType: "semantic",
+    redisType: null,
   },
   {
     name: "semantic_cache_scope",
@@ -200,7 +199,7 @@ export const CACHE_FIELDS: readonly CacheField[] = [
     section: "semantic",
     helpText:
       "Who can share a semantic cache hit. Key shares hits between all end users of a key/team/org. End user also isolates per end user; requests without an end user fall back to the key scope.",
-    redisType: "semantic",
+    redisType: null,
     defaultValue: "key",
     options: [
       { value: "key", label: "Key (shared by all end users of the key/team/org)" },

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.test.ts
@@ -51,6 +51,10 @@ describe("buildCachePayload", () => {
       port: "6379",
       ssl: false,
       ssl_check_hostname: false,
+      // semantic caching is off, so its fields are explicitly cleared
+      similarity_threshold: null,
+      redis_semantic_cache_embedding_model: null,
+      semantic_cache_scope: null,
     });
     expect(payload).not.toHaveProperty("redis_type");
     expect(payload).not.toHaveProperty("username");
@@ -70,21 +74,50 @@ describe("buildCachePayload", () => {
     expect(payload).not.toHaveProperty("redis_startup_nodes");
   });
 
-  it("should send type redis-semantic when saving a semantic cache", () => {
-    const payload = buildCachePayload("semantic", { similarity_threshold: 0.9 }, { forTesting: false });
+  it("should send type redis-semantic when saving with semantic caching enabled", () => {
+    const payload = buildCachePayload(
+      "node",
+      { similarity_threshold: 0.9 },
+      { forTesting: false, semanticEnabled: true },
+    );
     expect(payload.type).toBe("redis-semantic");
     expect(payload.similarity_threshold).toBe(0.9);
   });
 
-  it("should send the semantic cache scope only for a semantic cache", () => {
-    const semantic = buildCachePayload("semantic", { semantic_cache_scope: "end_user" }, { forTesting: false });
-    expect(semantic.semantic_cache_scope).toBe("end_user");
-    const node = buildCachePayload("node", { semantic_cache_scope: "end_user" }, { forTesting: false });
-    expect(node).not.toHaveProperty("semantic_cache_scope");
+  it("should send null for semantic fields when semantic caching is disabled, so turning it off clears them", () => {
+    const payload = buildCachePayload(
+      "node",
+      { similarity_threshold: 0.9 },
+      { forTesting: false, semanticEnabled: false },
+    );
+    expect(payload.type).toBe("redis");
+    expect(payload.similarity_threshold).toBe(null);
+    expect(payload.redis_semantic_cache_embedding_model).toBe(null);
   });
 
-  it("should keep type redis when testing a semantic cache so the test endpoint accepts it", () => {
-    const payload = buildCachePayload("semantic", { similarity_threshold: 0.9 }, { forTesting: true });
+  it("should send the semantic cache scope only when semantic caching is enabled", () => {
+    const enabled = buildCachePayload(
+      "node",
+      { semantic_cache_scope: "end_user" },
+      { forTesting: false, semanticEnabled: true },
+    );
+    expect(enabled.semantic_cache_scope).toBe("end_user");
+    // Disabled sends an explicit null rather than omitting the field, so a scope
+    // configured earlier is cleared on the server instead of silently surviving.
+    const disabled = buildCachePayload(
+      "node",
+      { semantic_cache_scope: "end_user" },
+      { forTesting: false, semanticEnabled: false },
+    );
+    expect(disabled.semantic_cache_scope).toBe(null);
+  });
+
+  it("should keep type redis when testing with semantic caching enabled so the test endpoint accepts it", () => {
+    const payload = buildCachePayload(
+      "node",
+      { similarity_threshold: 0.9 },
+      { forTesting: true, semanticEnabled: true },
+    );
     expect(payload.type).toBe("redis");
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.test.ts
@@ -51,10 +51,6 @@ describe("buildCachePayload", () => {
       port: "6379",
       ssl: false,
       ssl_check_hostname: false,
-      // semantic caching is off, so its fields are explicitly cleared
-      similarity_threshold: null,
-      redis_semantic_cache_embedding_model: null,
-      semantic_cache_scope: null,
     });
     expect(payload).not.toHaveProperty("redis_type");
     expect(payload).not.toHaveProperty("username");
@@ -84,15 +80,15 @@ describe("buildCachePayload", () => {
     expect(payload.similarity_threshold).toBe(0.9);
   });
 
-  it("should send null for semantic fields when semantic caching is disabled, so turning it off clears them", () => {
+  it("should omit semantic fields when semantic caching is disabled, even if they hold values", () => {
     const payload = buildCachePayload(
       "node",
-      { similarity_threshold: 0.9 },
+      { similarity_threshold: 0.9, redis_semantic_cache_embedding_model: "text-embedding-3-small" },
       { forTesting: false, semanticEnabled: false },
     );
     expect(payload.type).toBe("redis");
-    expect(payload.similarity_threshold).toBe(null);
-    expect(payload.redis_semantic_cache_embedding_model).toBe(null);
+    expect(payload).not.toHaveProperty("similarity_threshold");
+    expect(payload).not.toHaveProperty("redis_semantic_cache_embedding_model");
   });
 
   it("should send the semantic cache scope only when semantic caching is enabled", () => {
@@ -102,14 +98,14 @@ describe("buildCachePayload", () => {
       { forTesting: false, semanticEnabled: true },
     );
     expect(enabled.semantic_cache_scope).toBe("end_user");
-    // Disabled sends an explicit null rather than omitting the field, so a scope
-    // configured earlier is cleared on the server instead of silently surviving.
+    // Disabled must omit the scope rather than send null: the backend rejects a null scope
+    // when it rebuilds the cache, while an omitted one falls back to its default.
     const disabled = buildCachePayload(
       "node",
       { semantic_cache_scope: "end_user" },
       { forTesting: false, semanticEnabled: false },
     );
-    expect(disabled.semantic_cache_scope).toBe(null);
+    expect(disabled).not.toHaveProperty("semantic_cache_scope");
   });
 
   it("should keep type redis when testing with semantic caching enabled so the test endpoint accepts it", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.ts
@@ -2,7 +2,7 @@ import { CACHE_FIELDS, CacheField, CacheSection, REDACTED_VALUE, RedisType } fro
 
 export type CacheFormValue = string | number | boolean | null | undefined;
 export type CacheFormValues = Record<string, CacheFormValue>;
-export type CacheSavePayloadValue = string | number | boolean | unknown[];
+export type CacheSavePayloadValue = string | number | boolean | unknown[] | null;
 export type CacheSavePayload = Record<string, CacheSavePayloadValue>;
 
 export const isFieldVisible = (field: CacheField, redisType: RedisType): boolean =>
@@ -89,13 +89,18 @@ const saveValueForField = (field: CacheField, raw: CacheFormValue): CacheSavePay
 export const buildCachePayload = (
   redisType: RedisType,
   values: CacheFormValues,
-  { forTesting }: { forTesting: boolean },
+  { forTesting, semanticEnabled = false }: { forTesting: boolean; semanticEnabled?: boolean },
 ): CacheSavePayload => {
-  const type = !forTesting && redisType === "semantic" ? "redis-semantic" : "redis";
+  const type = !forTesting && semanticEnabled ? "redis-semantic" : "redis";
 
   const entries = CACHE_FIELDS.filter((field) => isFieldVisible(field, redisType)).flatMap((field) => {
+    // Semantic fields are always visible now, so clearing the toggle has to send an
+    // explicit null - omitting them would leave the previous values on the server.
+    if (field.section === "semantic" && !semanticEnabled) {
+      return [[field.name, null] as [string, CacheSavePayloadValue]];
+    }
     const value = saveValueForField(field, values[field.name]);
-    return value === undefined ? [] : [[field.name, value] as const];
+    return value === undefined ? [] : [[field.name, value] as [string, CacheSavePayloadValue]];
   });
 
   return { type, ...Object.fromEntries(entries) };

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.ts
@@ -94,10 +94,11 @@ export const buildCachePayload = (
   const type = !forTesting && semanticEnabled ? "redis-semantic" : "redis";
 
   const entries = CACHE_FIELDS.filter((field) => isFieldVisible(field, redisType)).flatMap((field) => {
-    // Semantic fields are always visible now, so clearing the toggle has to send an
-    // explicit null - omitting them would leave the previous values on the server.
+    // Semantic fields are always visible now, so leave them out when the toggle is off. The
+    // backend stores the payload as sent, which already clears them; an explicit null would
+    // reach Cache(semantic_cache_scope=None) and fail both the save and the connection test.
     if (field.section === "semantic" && !semanticEnabled) {
-      return [[field.name, null] as [string, CacheSavePayloadValue]];
+      return [];
     }
     const value = saveValueForField(field, values[field.name]);
     return value === undefined ? [] : [[field.name, value] as [string, CacheSavePayloadValue]];

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.integration.test.tsx
@@ -61,10 +61,6 @@ describe("CacheSettings advanced settings round-trip", () => {
       namespace: "prod-ns",
       ttl: 300,
       max_connections: 50,
-      // semantic caching is off, so its fields are cleared explicitly
-      similarity_threshold: null,
-      redis_semantic_cache_embedding_model: null,
-      semantic_cache_scope: null,
     });
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.integration.test.tsx
@@ -61,6 +61,10 @@ describe("CacheSettings advanced settings round-trip", () => {
       namespace: "prod-ns",
       ttl: 300,
       max_connections: 50,
+      // semantic caching is off, so its fields are cleared explicitly
+      similarity_threshold: null,
+      redis_semantic_cache_embedding_model: null,
+      semantic_cache_scope: null,
     });
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.test.tsx
@@ -63,12 +63,35 @@ describe("CacheSettings", () => {
     });
   });
 
-  describe("when the redis type is semantic", () => {
-    it("should reveal the semantic fields", async () => {
+  describe("semantic caching", () => {
+    it("should not offer Semantic as a redis type, since it is not a topology", async () => {
+      renderSettings();
+      await screen.findByText("Redis Type");
+      expect(screen.queryByText("Semantic")).not.toBeInTheDocument();
+    });
+
+    it("should stay collapsed until the toggle is switched on", async () => {
+      const user = userEvent.setup();
+      renderSettings();
+      expect(await screen.findByText("Enable Semantic Caching")).toBeInTheDocument();
+      expect(screen.queryByText("Similarity Threshold")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("switch"));
+      expect(await screen.findByText("Similarity Threshold")).toBeInTheDocument();
+      expect(screen.getByText("Embedding Model")).toBeInTheDocument();
+    });
+
+    it("should reveal the semantic fields for a config saved under the old redis_type", async () => {
       getCacheSettingsCall.mockResolvedValue({ current_values: { redis_type: "semantic" } });
       renderSettings();
       expect(await screen.findByText("Similarity Threshold")).toBeInTheDocument();
       expect(screen.getByText("Embedding Model")).toBeInTheDocument();
+    });
+
+    it("should reveal the semantic fields when only the semantic values are set", async () => {
+      getCacheSettingsCall.mockResolvedValue({ current_values: { redis_type: "node", similarity_threshold: 0.9 } });
+      renderSettings();
+      expect(await screen.findByText("Similarity Threshold")).toBeInTheDocument();
     });
   });
 
@@ -128,6 +151,10 @@ describe("CacheSettings", () => {
           port: "6379",
           ssl: false,
           ssl_check_hostname: false,
+          // semantic caching is off, so its fields are cleared explicitly
+          similarity_threshold: null,
+          redis_semantic_cache_embedding_model: null,
+          semantic_cache_scope: null,
         }),
       );
     });

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.test.tsx
@@ -151,10 +151,6 @@ describe("CacheSettings", () => {
           port: "6379",
           ssl: false,
           ssl_check_hostname: false,
-          // semantic caching is off, so its fields are cleared explicitly
-          similarity_threshold: null,
-          redis_semantic_cache_embedding_model: null,
-          semantic_cache_scope: null,
         }),
       );
     });

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.tsx
@@ -6,6 +6,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { getCacheSettingsCall, testCacheConnectionCall, updateCacheSettingsCall } from "@/components/networking";
 import { fetchAvailableModels, ModelGroup } from "@/components/llm_calls/fetch_models";
 import { toast } from "@/lib/toast";
+import { Switch } from "@/components/ui/switch";
 import RedisTypeSelector from "./RedisTypeSelector";
 import CacheFieldSection from "./CacheFieldSection";
 import { EmbeddingModelOption } from "./CacheFormField";
@@ -37,6 +38,7 @@ const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
   const [isTesting, setIsTesting] = useState<boolean>(false);
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [configuredSecrets, setConfiguredSecrets] = useState<ReadonlySet<string>>(new Set());
+  const [semanticEnabled, setSemanticEnabled] = useState<boolean>(false);
 
   const loadCacheSettings = useCallback(async () => {
     if (!accessToken) {
@@ -48,6 +50,12 @@ const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
       form.reset(buildInitialValues(currentValues));
       setConfiguredSecrets(configuredSecretFields(currentValues));
       setRedisType(toRedisType(currentValues.redis_type));
+      // "semantic" is no longer a redis_type, but existing configs were saved with it.
+      setSemanticEnabled(
+        currentValues.redis_type === "semantic" ||
+          currentValues.similarity_threshold != null ||
+          currentValues.redis_semantic_cache_embedding_model != null,
+      );
     } catch (error) {
       console.error("Failed to load cache settings:", error);
       toast.fromError("Failed to load cache settings");
@@ -102,7 +110,7 @@ const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
     try {
       const result = await testCacheConnectionCall(
         accessToken,
-        buildCachePayload(redisType, values, { forTesting: true }),
+        buildCachePayload(redisType, values, { forTesting: true, semanticEnabled }),
       );
       if (result.status === "success") {
         toast.success("Cache connection test successful!");
@@ -128,7 +136,10 @@ const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
 
     setIsSaving(true);
     try {
-      await updateCacheSettingsCall(accessToken, buildCachePayload(redisType, values, { forTesting: false }));
+      await updateCacheSettingsCall(
+        accessToken,
+        buildCachePayload(redisType, values, { forTesting: false, semanticEnabled }),
+      );
       toast.success("Cache settings updated successfully");
       await loadCacheSettings();
     } catch (error) {
@@ -192,16 +203,25 @@ const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
             </div>
           )}
 
-          {redisType === "semantic" && (
-            <div className="pt-4 border-t border-border">
+          <div className="pt-4 border-t border-border">
+            <div className="mb-4 flex items-center gap-3">
+              <Switch checked={semanticEnabled} onCheckedChange={setSemanticEnabled} />
+              <div>
+                <span className="text-sm font-medium text-foreground">Enable Semantic Caching</span>
+                <p className="text-xs text-muted-foreground">
+                  Reuse responses for semantically similar prompts using embedding vectors
+                </p>
+              </div>
+            </div>
+            {semanticEnabled && (
               <CacheFieldSection
                 title="Semantic Configuration"
                 section="semantic"
                 redisType={redisType}
                 embeddingModels={embeddingModels}
               />
-            </div>
-          )}
+            )}
+          </div>
 
           <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen} className="mt-4">
             <CollapsibleTrigger className="group flex w-full items-center justify-between py-2 text-left">


### PR DESCRIPTION
## TLDR

Problem this solves:

- "Semantic" sits in the Redis Type dropdown beside Node, Cluster and Sentinel
- Semantic is a caching strategy, the other three are how Redis is deployed

How it solves it:

- Removes "Semantic" from the Redis Type dropdown
- Adds a separate "Enable Semantic Caching" toggle for a Node
- Disables the toggle for Cluster and Sentinel, which the semantic cache cannot use
- Configs saved the old way still load with the toggle on

This continues #32758, which waited since July and was closed on 13 Sep without a comment. Review bots found two bugs in earlier revisions of this PR, both fixed here and described under Caveats

## User Flow

Before: a proxy admin enabling semantic caching has to pick it as if it were a kind of Redis deployment

1. They open https://litellm-domain/ui/?page=caching and go to the **Cache Settings** tab
2. The **Redis Type** dropdown offers Node, Cluster, Sentinel and Semantic
3. They want semantic caching on their single Redis node, so they pick Semantic, and the dropdown no longer says Node
4. They click **Save Changes** and the cache is saved as a semantic cache

After: the same admin picks Node as their Redis type and turns semantic caching on separately

1. They open https://litellm-domain/ui/?page=caching and go to the **Cache Settings** tab
2. The **Redis Type** dropdown offers Node, Cluster and Sentinel
3. They pick Node and switch on **Enable Semantic Caching**, and the semantic settings appear
4. They click **Save Changes** and the cache is saved as a semantic cache
5. If they pick Cluster or Sentinel instead, the toggle is greyed out with a note that semantic caching needs a single Redis node

## Relevant issues

Fixes #32621

Continues #32758, which was closed without review

## Affected release

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: the save-payload builder that the **Save Changes** button calls, run with the values below at each commit. The output is the body the dashboard sends to `POST /cache/settings`, with nothing mocked. This is not yet the live-proxy screenshot proof the repository asks for, see Caveats

```
host: localhost, port: 6379, redis_startup_nodes: [{"host":"10.0.0.1","port":"7001"}],
similarity_threshold: 0.9, redis_semantic_cache_embedding_model: text-embedding-3-small,
semantic_cache_scope: end_user
```

### Before (c2c2a623c0, merge base on `litellm_internal_staging`)

#### Redis types offered

1. List the Redis Type options
2. Observed: `["node","cluster","sentinel","semantic"]`

#### Semantic caching off on a Node

1. Build the payload for Redis Type Node
2. Observed: `{"type":"redis","host":"localhost","port":"6379","ssl":false,"ssl_check_hostname":false}`

#### Semantic caching on

1. Build the payload for Redis Type Semantic, the only way to turn it on
2. Observed: `{"type":"redis-semantic","host":"localhost","port":"6379","similarity_threshold":0.9,"redis_semantic_cache_embedding_model":"text-embedding-3-small","semantic_cache_scope":"end_user","ssl":false,"ssl_check_hostname":false}`

#### Cluster

1. Build the payload for Redis Type Cluster, where semantic caching cannot be selected
2. Observed: `{"type":"redis","host":"localhost","port":"6379","redis_startup_nodes":[{"host":"10.0.0.1","port":"7001"}],"ssl":false,"ssl_check_hostname":false}`

### After (40aa2bf639, PR tip; captured at 7b5042842c, which differs only in formatting)

#### Redis types offered

1. List the Redis Type options
2. Observed: `["node","cluster","sentinel"]`

#### Semantic caching off on a Node

1. Build the payload for Redis Type Node with the toggle off
2. Observed: `{"type":"redis","host":"localhost","port":"6379","ssl":false,"ssl_check_hostname":false}`

#### Semantic caching on

1. Build the payload for Redis Type Node with the toggle on
2. Observed: `{"type":"redis-semantic","host":"localhost","port":"6379","similarity_threshold":0.9,"redis_semantic_cache_embedding_model":"text-embedding-3-small","semantic_cache_scope":"end_user","ssl":false,"ssl_check_hostname":false}`

#### Cluster

1. Build the payload for Redis Type Cluster with the toggle state left on, which the UI shows greyed out
2. Observed: `{"type":"redis","host":"localhost","port":"6379","redis_startup_nodes":[{"host":"10.0.0.1","port":"7001"}],"ssl":false,"ssl_check_hostname":false}`, so no semantic cache is requested for a topology it cannot connect to

Test run at `40aa2bf639`: the whole `cache_settings` folder, 4 test files, 45 tests pass with no type errors, and `prettier --check` is clean. Making the Node-only check always true fails 4 of them, and dropping the `type: redis-semantic` load signal fails 1

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- No live-proxy screenshots yet
  - Proof above runs the real payload builder, not a running dashboard
  - Happy to add screenshots if a reviewer wants them

### Low

- Earlier revisions of this PR had two bugs, both fixed
  - Toggle off sent `semantic_cache_scope: null`, which `Cache.__init__` rejects, so plain Redis saves returned 500 (found by Veria)
  - The toggle allowed Cluster and Sentinel, but the `redis-semantic` backend only connects to one `host:port` (found by Greptile)
- Old saved configs turn the toggle on from `type: redis-semantic`, `redis_type: semantic`, a similarity threshold or an embedding model
  - A semantic config saved with any other shape loads with the toggle off

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
