### PR TITLE
fix(router): honor wildcard and provider-stripped fallback keys in context_window/content_policy fallbacks

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8008,18 +8008,13 @@ class Router:
         fallbacks: list[dict[str, list[str]]],  # mutable-ok: mirrors the sibling resolver's contract
         lookup_groups: tuple[str, ...],
     ) -> list[str] | None:  # mutable-ok: mirrors the sibling resolver's contract
-        """First lookup group whose exact-key chain resolves (tier first, then requested group)."""
-        return next(
-            (
-                resolved
-                for resolved in (
-                    self._get_fallback_model_group_from_fallbacks(fallbacks=fallbacks, model_group=group)
-                    for group in lookup_groups
-                )
-                if resolved is not None
-            ),
-            None,
+        """First lookup group with a specifically-keyed chain wins (tier first, then requested
+        group); a generic "*" chain applies only once every group has missed a specific
+        match, so it cannot shadow a later group's own chain."""
+        fallback_model_group, _ = get_fallback_model_group_for_lookup_groups(
+            fallbacks=fallbacks, lookup_groups=lookup_groups
         )
+        return fallback_model_group
 
     def _get_first_default_fallback(self) -> str | None:
         """

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7994,11 +7994,13 @@ class Router:
         if model_group is None:
             return None
 
-        fallback_model_group: list[str] | None = None
-        for item in fallbacks:  # [{"gpt-3.5-turbo": ["gpt-4"]}]
-            if list(item.keys())[0] == model_group:
-                fallback_model_group = item[model_group]
-                break
+        from litellm.router_utils.fallback_event_handlers import (
+            get_fallback_model_group,
+        )
+
+        fallback_model_group, _ = get_fallback_model_group(
+            fallbacks=fallbacks, model_group=model_group
+        )
         return fallback_model_group
 
     def _get_fallback_model_group_for_lookup_groups(

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -10609,6 +10609,38 @@ class TestGetAllowedFailsFromPolicy:
         assert router.get_allowed_fails_from_policy(exc) is None
 
 
+def test_get_fallback_model_group_from_fallbacks_honors_wildcard_and_stripped_keys():
+    """_get_fallback_model_group_from_fallbacks (used for context_window_fallbacks and
+    content_policy_fallbacks) did an exact-key match only, while the canonical
+    get_fallback_model_group resolver used by the regular fallbacks path also honors
+    provider-stripped keys and the "*" wildcard. A "*" or provider-prefixed fallback
+    config was silently ignored, and the original exception was re-raised as if no
+    fallback were configured."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo"},
+            }
+        ],
+    )
+
+    assert router._get_fallback_model_group_from_fallbacks(
+        fallbacks=[{"gpt-3.5-turbo": ["gpt-4"]}],
+        model_group="gpt-3.5-turbo",
+    ) == ["gpt-4"]
+
+    assert router._get_fallback_model_group_from_fallbacks(
+        fallbacks=[{"*": ["gpt-4"]}],
+        model_group="gpt-3.5-turbo",
+    ) == ["gpt-4"]
+
+    assert router._get_fallback_model_group_from_fallbacks(
+        fallbacks=[{"gpt-3.5-turbo": ["gpt-4"]}],
+        model_group="openai/gpt-3.5-turbo",
+    ) == ["gpt-4"]
+
+
 class _LogCapture(logging.Handler):
     def __init__(self, level):
         super().__init__(level=level)

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -10641,6 +10641,32 @@ def test_get_fallback_model_group_from_fallbacks_honors_wildcard_and_stripped_ke
     ) == ["gpt-4"]
 
 
+def test_get_fallback_model_group_for_lookup_groups_prefers_specific_chain_over_earlier_wildcard():
+    """A "*" wildcard match for an earlier (tier-specific) lookup group must not shadow a
+    later lookup group's own specifically-keyed fallback chain. Once the single-group
+    resolver started honoring "*", naively taking the first non-None result across
+    lookup_groups let the tier-specific group's wildcard match win over the requested
+    group's own exact match -- delegate to the canonical multi-group resolver instead,
+    which only falls back to "*" once every group has missed a specific match."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo"},
+            }
+        ],
+    )
+
+    resolved = router._get_fallback_model_group_for_lookup_groups(
+        fallbacks=[
+            {"*": ["generic-fallback"]},
+            {"gpt-3.5-turbo": ["specific-fallback"]},
+        ],
+        lookup_groups=("tier:premium/gpt-3.5-turbo", "gpt-3.5-turbo"),
+    )
+    assert resolved == ["specific-fallback"]
+
+
 class _LogCapture(logging.Handler):
     def __init__(self, level):
         super().__init__(level=level)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `_get_fallback_model_group_from_fallbacks` (used to resolve `context_window_fallbacks` and `content_policy_fallbacks`) does an exact key match only
- The regular `fallbacks` path resolves through `get_fallback_model_group` instead, which also honors provider-stripped keys and the `"*"` wildcard
- The two lookups drifted: a `context_window_fallbacks=[{"*": [...]}]` or a provider-prefixed model group silently does nothing, the lookup returns `None`, and the original exception is re-raised as if no fallback were configured

## Fix

Delegate to the canonical `get_fallback_model_group` resolver instead of duplicating a weaker exact-match loop, so `context_window_fallbacks`/`content_policy_fallbacks` behave consistently with the regular `fallbacks` path.

## Note

This resubmits #35689, which got auto-closed when its base branch (`litellm_internal_staging`) was deleted/reset in the middle of review -- the fix itself was never landed, so I rebuilt it fresh against current `main`.

## Testing

Added `test_get_fallback_model_group_from_fallbacks_honors_wildcard_and_stripped_keys`, covering exact match, `"*"` wildcard, and provider-stripped key resolution.
