### PR TITLE
fix(vector_store): prevent prompt caching from starving vector store pre-call hook (#40908)

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1005,6 +1005,37 @@ class Logging(LiteLLMLoggingBaseClass):
                     AnthropicCacheControlHook.count_request_cache_breakpoints(messages) - breakpoints_before,
                     injected_for_every_deployment=injected_for_every_deployment,
                 )
+
+        if (
+            not isinstance(custom_logger, AnthropicCacheControlHook)
+            and (
+                cache_control_logger := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(
+                    non_default_params or {}
+                )
+            )
+        ):
+            cache_breakpoints_before: Final = AnthropicCacheControlHook.count_request_cache_breakpoints(messages)
+            (
+                model,
+                messages,
+                non_default_params,
+            ) = cache_control_logger.get_chat_completion_prompt(
+                model=model,
+                messages=messages,
+                non_default_params=non_default_params or {},
+                prompt_id=prompt_id,
+                prompt_spec=prompt_spec,
+                prompt_variables=prompt_variables,
+                dynamic_callback_params=self.standard_callback_dynamic_params,
+                prompt_label=prompt_label,
+                prompt_version=prompt_version,
+            )
+            if request_kwargs is not None:
+                AnthropicCacheControlHook.record_gateway_injection(
+                    request_kwargs,
+                    AnthropicCacheControlHook.count_request_cache_breakpoints(messages) - cache_breakpoints_before,
+                    injected_for_every_deployment=injected_for_every_deployment,
+                )
         self.messages = messages
         return model, messages, non_default_params
 
@@ -1057,6 +1088,39 @@ class Logging(LiteLLMLoggingBaseClass):
                 AnthropicCacheControlHook.record_gateway_injection(
                     request_kwargs,
                     AnthropicCacheControlHook.count_request_cache_breakpoints(messages) - breakpoints_before,
+                    injected_for_every_deployment=injected_for_every_deployment,
+                )
+
+        if (
+            not isinstance(custom_logger, AnthropicCacheControlHook)
+            and (
+                cache_control_logger := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(
+                    non_default_params or {}
+                )
+            )
+        ):
+            cache_breakpoints_before: Final = AnthropicCacheControlHook.count_request_cache_breakpoints(messages)
+            (
+                model,
+                messages,
+                non_default_params,
+            ) = await cache_control_logger.async_get_chat_completion_prompt(
+                model=model,
+                messages=messages,
+                non_default_params=non_default_params or {},
+                prompt_id=prompt_id,
+                prompt_spec=prompt_spec,
+                prompt_variables=prompt_variables,
+                dynamic_callback_params=self.standard_callback_dynamic_params,
+                litellm_logging_obj=self,
+                tools=tools,
+                prompt_label=prompt_label,
+                prompt_version=prompt_version,
+            )
+            if request_kwargs is not None:
+                AnthropicCacheControlHook.record_gateway_injection(
+                    request_kwargs,
+                    AnthropicCacheControlHook.count_request_cache_breakpoints(messages) - cache_breakpoints_before,
                     injected_for_every_deployment=injected_for_every_deployment,
                 )
         self.messages = messages
@@ -1177,17 +1241,18 @@ class Logging(LiteLLMLoggingBaseClass):
             self.model_call_details["prompt_integration"] = logger.__class__.__name__
             return logger
 
-        if (
-            anthropic_cache_control_logger
-            := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(non_default_params)
-        ):
-            self.model_call_details["prompt_integration"] = anthropic_cache_control_logger.__class__.__name__
-            return anthropic_cache_control_logger
-
         #########################################################
         # Vector Store / Knowledge Base hooks
         #########################################################
-        if litellm.vector_store_registry is not None:
+        if (
+            litellm.vector_store_registry is not None
+            and (
+                litellm.vector_store_registry.get_vector_store_to_run(
+                    non_default_params=non_default_params, tools=tools
+                )
+                or non_default_params.get("vector_store_ids")
+            )
+        ):
             vector_store_custom_logger: Final = _init_custom_logger_compatible_class(
                 logging_integration="vector_store_pre_call_hook",
                 internal_usage_cache=None,
@@ -1198,6 +1263,13 @@ class Logging(LiteLLMLoggingBaseClass):
             if vector_store_custom_logger and vector_store_custom_logger not in litellm.callbacks:
                 litellm.logging_callback_manager.add_litellm_callback(vector_store_custom_logger)
             return vector_store_custom_logger
+
+        if (
+            anthropic_cache_control_logger
+            := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(non_default_params)
+        ):
+            self.model_call_details["prompt_integration"] = anthropic_cache_control_logger.__class__.__name__
+            return anthropic_cache_control_logger
 
         return None
 

--- a/tests/test_litellm/integrations/vector_store_integrations/test_vector_store_pre_call_hook.py
+++ b/tests/test_litellm/integrations/vector_store_integrations/test_vector_store_pre_call_hook.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Protocol
 
 import pytest
@@ -567,3 +568,85 @@ async def test_a_crash_outside_the_search_names_the_requested_vector_stores(
     assert [record.getMessage() for record in warnings] == [
         "Error in VectorStorePreCallHook for vector_store_ids=('vs-one', 'vs-two'): the registry blew up"
     ]
+
+
+@pytest.mark.asyncio
+async def test_vector_store_hook_selected_when_prompt_caching_enabled(
+    registry_with: RegisterStores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression (#40908): prompt caching must not starve vector store pre-call hook."""
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    registry_with("vs-test")
+    monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+
+    logging_obj = Logging(
+        model="claude-3-5-sonnet-20241022",
+        messages=[{"role": "user", "content": "hello"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.now(timezone.utc),
+        litellm_call_id="call-40908",
+        function_id="fn-40908",
+    )
+    non_default_params = {
+        "vector_store_ids": ["vs-test"],
+        "cache_control_injection_points": [{"location": "message", "index": -1}],
+    }
+
+    custom_logger = logging_obj.get_custom_logger_for_prompt_management(
+        model="claude-3-5-sonnet-20241022",
+        non_default_params=non_default_params,
+    )
+
+    assert isinstance(custom_logger, VectorStorePreCallHook)
+
+
+@pytest.mark.asyncio
+async def test_vector_store_and_anthropic_prompt_caching_composition(
+    registry_with: RegisterStores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression (#40908): vector store retrieval and prompt caching must compose cleanly."""
+    from litellm.litellm_core_utils.litellm_logging import Logging
+    from litellm.proxy import proxy_server
+
+    registry_with("vs-test")
+    router = RecordingRouter()
+    monkeypatch.setattr(proxy_server, "llm_router", router)
+    monkeypatch.setattr(proxy_server, "prisma_client", None)
+    monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+
+    logging_obj = Logging(
+        model="claude-3-5-sonnet-20241022",
+        messages=[{"role": "user", "content": "what is litellm?"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.now(timezone.utc),
+        litellm_call_id="call-40908",
+        function_id="fn-40908",
+    )
+    non_default_params = {
+        "vector_store_ids": ["vs-test"],
+        "cache_control_injection_points": [{"location": "message", "index": -1}],
+    }
+    messages = [{"role": "user", "content": "what is litellm?"}]
+
+    model, updated_messages, remaining_params = await logging_obj.async_get_chat_completion_prompt(
+        model="claude-3-5-sonnet-20241022",
+        messages=messages,
+        non_default_params=non_default_params,
+        prompt_id=None,
+        prompt_variables=None,
+    )
+
+    assert model == "claude-3-5-sonnet-20241022"
+
+    # 1. Vector store context retrieved and prepended
+    assert any("context from vs-test" in str(msg.get("content", "")) for msg in updated_messages)
+    # 2. vector_store_ids popped so upstream provider doesn't fail with unexpected parameter
+    assert "vector_store_ids" not in remaining_params
+    # 3. Prompt caching cache_control breakpoint injected on the enriched messages
+    assert any("cache_control" in msg for msg in updated_messages)
+


### PR DESCRIPTION
## TLDR

Problem this solves:

- `enable_anthropic_prompt_caching` starves the vector-store pre-call hook
- `vector_store_ids` is left un-popped in request params, causing upstream 400 errors

How it solves it:

- Prioritizes `VectorStorePreCallHook` logger selection when vector stores are configured
- Composes Anthropic cache breakpoint injection after prompt hooks complete

## User Flow

Before: A developer enables Anthropic prompt caching and passes `vector_store_ids` to retrieve grounding context.

1. The developer sends `POST /v1/chat/completions` with `"vector_store_ids": ["my-store"]` and prompt caching configured.
2. Prompt caching hook is selected as the sole custom logger, starving the vector store hook.
3. No vector context is retrieved and `vector_store_ids` remains in the request payload sent upstream.
4. Upstream provider rejects the request with HTTP 400 (`vector_store_ids: Extra inputs are not permitted`).

After: The same request retrieves vector store context and injects cache breakpoints.

1. The developer sends `POST /v1/chat/completions` with `"vector_store_ids": ["my-store"]` and prompt caching configured.
2. `VectorStorePreCallHook` runs first: queries the vector store, injects retrieved context, and pops `vector_store_ids`.
3. Anthropic cache control hook subsequently runs on the augmented messages, adding ephemeral cache breakpoints.
4. The request succeeds with both vector grounding and prompt caching active.

## Relevant issues

Fixes #40908

## Type

🐛 Bug Fix

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally (`pytest tests/test_litellm/integrations/vector_store_integrations/test_vector_store_pre_call_hook.py`)
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

### Before (2567b85d34^)

1. When `enable_anthropic_prompt_caching=True` and `vector_store_ids=["vs-test"]`:
   `Logging.get_custom_logger_for_prompt_management(...)` returned `AnthropicCacheControlHook`, starving `VectorStorePreCallHook`.
2. Upstream provider received unexpected `vector_store_ids` parameter and failed with `HTTP 400: Extra inputs are not permitted`.

### After (2567b85d34)

1. `Logging.get_custom_logger_for_prompt_management(...)` returns `VectorStorePreCallHook`.
2. `async_get_chat_completion_prompt` executes vector store retrieval, prepends context, pops `vector_store_ids`, and subsequently executes `AnthropicCacheControlHook` to inject `cache_control` breakpoints:
```python
# test_vector_store_pre_call_hook.py
# 1. Vector store context retrieved and prepended
assert any("context from vs-test" in str(msg.get("content", "")) for msg in updated_messages)
# 2. vector_store_ids popped so upstream provider doesn't fail with unexpected parameter
assert "vector_store_ids" not in remaining_params
# 3. Prompt caching cache_control breakpoint injected on the enriched messages
assert any("cache_control" in msg for msg in updated_messages)
```
Passes all 19 tests in `test_vector_store_pre_call_hook.py` and all 225 tests in `test_anthropic_cache_control_hook.py`.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
