### PR TITLE
fix(proxy/logging): case-insensitive User-Agent header lookup in _get_user_agent_tags

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5941,18 +5941,22 @@ class StandardLoggingPayloadSetup:
         user_agent_tags: list[str] | None = None
         headers: Final = proxy_server_request.get("headers", {})
         if headers is not None and isinstance(headers, dict):
-            if "user-agent" in headers:
-                user_agent: Final = headers["user-agent"]
-                if user_agent is not None:
-                    if user_agent_tags is None:
-                        user_agent_tags = []
-                    user_agent_part: str | None = None
-                    if "/" in user_agent:
-                        user_agent_part = user_agent.split("/")[0]
-                    if user_agent_part is not None:
-                        user_agent_tags.append("User-Agent: " + user_agent_part)
-                    if user_agent is not None:
-                        user_agent_tags.append("User-Agent: " + user_agent)
+            user_agent: Final[str | None] = next(
+                (
+                    v
+                    for k, v in headers.items()
+                    if isinstance(k, str) and k.lower() == "user-agent" and isinstance(v, str)
+                ),
+                None,
+            )
+            if user_agent is not None:
+                user_agent_tags = []
+                user_agent_part: str | None = None
+                if "/" in user_agent:
+                    user_agent_part = user_agent.split("/")[0]
+                if user_agent_part is not None:
+                    user_agent_tags.append("User-Agent: " + user_agent_part)
+                user_agent_tags.append("User-Agent: " + user_agent)
         return user_agent_tags
 
     @staticmethod

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1888,8 +1888,25 @@ def test_get_user_agent_tags():
         }
     )
 
+    assert tags is not None
     assert "User-Agent: litellm" in tags
     assert "User-Agent: litellm/0.1.0" in tags
+
+
+def test_get_user_agent_tags_case_insensitive():
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    tags = StandardLoggingPayloadSetup._get_user_agent_tags(
+        proxy_server_request={
+            "headers": {
+                "User-Agent": "curl/7.68.0",
+            }
+        }
+    )
+
+    assert tags is not None
+    assert "User-Agent: curl" in tags
+    assert "User-Agent: curl/7.68.0" in tags
 
 
 def test_get_request_tags():
@@ -3977,9 +3994,7 @@ def test_get_standard_logging_object_payload_carries_matched_access_groups(loggi
             "model": "gpt-4o",
             "messages": [],
             "litellm_params": {
-                "metadata": {
-                    "user_api_key_matched_model_access_groups": ["premium-pool", "shared-pool"]
-                },
+                "metadata": {"user_api_key_matched_model_access_groups": ["premium-pool", "shared-pool"]},
                 "proxy_server_request": {"body": {}},
             },
         },
@@ -4063,9 +4078,7 @@ def _model_router_response(selected_model: str, stamp: bool):
     from litellm.types.utils import ModelResponse
 
     response = ModelResponse(model=selected_model)
-    response._hidden_params = (
-        {AZURE_MODEL_ROUTER_SELECTED_MODEL_KEY: selected_model} if stamp else {}
-    )
+    response._hidden_params = {AZURE_MODEL_ROUTER_SELECTED_MODEL_KEY: selected_model} if stamp else {}
     return response
 
 
@@ -4089,9 +4102,7 @@ def test_standard_logging_payload_uses_stamped_model_router_model(logging_obj):
             "messages": [],
             "litellm_params": {"metadata": {}},
         },
-        init_response_obj=_model_router_response(
-            "azure_ai/grok-4-1-fast-reasoning", stamp=True
-        ),
+        init_response_obj=_model_router_response("azure_ai/grok-4-1-fast-reasoning", stamp=True),
         start_time=now,
         end_time=now,
         logging_obj=logging_obj,
@@ -4123,9 +4134,7 @@ def test_standard_logging_payload_keeps_requested_model_without_router_stamp(
             "messages": [],
             "litellm_params": {"metadata": {}},
         },
-        init_response_obj=_model_router_response(
-            "azure_ai/grok-4-1-fast-reasoning", stamp=False
-        ),
+        init_response_obj=_model_router_response("azure_ai/grok-4-1-fast-reasoning", stamp=False),
         start_time=now,
         end_time=now,
         logging_obj=logging_obj,
@@ -5537,9 +5546,7 @@ class TestNonInferenceCallTypesAreNotBilled:
             init_response_obj=self._retrieved_response(),
             start_time=now,
             end_time=now,
-            logging_obj=self._logging_obj(
-                "aget_responses", litellm_metadata=self.BACKGROUND_POLL_METADATA
-            ),
+            logging_obj=self._logging_obj("aget_responses", litellm_metadata=self.BACKGROUND_POLL_METADATA),
             status="success",
         )
 
@@ -5785,9 +5792,7 @@ async def test_streaming_success_callbacks_survive_cost_calculation_failure():
     releasing.async_log_success_event = AsyncMock()
 
     patcher, logging_obj = _streaming_logging_obj_with_callbacks([releasing])
-    with patcher, patch.object(
-        logging_obj, "_response_cost_calculator", side_effect=ValueError("bad usage block")
-    ):
+    with patcher, patch.object(logging_obj, "_response_cost_calculator", side_effect=ValueError("bad usage block")):
         await logging_obj.async_success_handler(result=_assembled_stream_result())
 
     assert logging_obj.model_call_details["response_cost"] is None
@@ -5800,8 +5805,9 @@ async def test_streaming_success_callbacks_survive_standard_logging_payload_fail
     releasing.async_log_success_event = AsyncMock()
 
     patcher, logging_obj = _streaming_logging_obj_with_callbacks([releasing])
-    with patcher, patch.object(
-        logging_obj, "_build_standard_logging_payload", side_effect=ValueError("incomplete stream")
+    with (
+        patcher,
+        patch.object(logging_obj, "_build_standard_logging_payload", side_effect=ValueError("incomplete stream")),
     ):
         await logging_obj.async_success_handler(result=_assembled_stream_result())
 
@@ -6149,6 +6155,8 @@ def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_pa
             )
         for hook in [cb for cb in litellm.callbacks if isinstance(cb, VectorStorePreCallHook)]:
             litellm.logging_callback_manager.remove_callback_from_list_by_object(litellm.callbacks, hook)
+
+
 def test_newrelic_dispatch_prefers_otel_v2_when_flag_on(monkeypatch):
     """With LITELLM_OTEL_V2 on and operator credentials present, the "newrelic"
     callback builds the OTel v2 logger (per-team credential routing); with the
@@ -6304,7 +6312,9 @@ def test_get_error_information_skips_traceback_for_budget_rejection_with_provide
     from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
 
     assert litellm.log_client_error_tracebacks is False
-    over_budget = _raise_and_catch(litellm.BudgetExceededError(current_cost=0.01, max_budget=0.0, llm_provider="anthropic"))
+    over_budget = _raise_and_catch(
+        litellm.BudgetExceededError(current_cost=0.01, max_budget=0.0, llm_provider="anthropic")
+    )
     result = StandardLoggingPayloadSetup.get_error_information(over_budget)
     assert result["error_code"] == "429"
     assert result["llm_provider"] == "anthropic"
@@ -6821,9 +6831,7 @@ def test_passthrough_embeddings_result_swapped_for_callbacks():
             ],
             "model": "EmbeddingsGigaR",
         },
-        request=httpx.Request(
-            "POST", "https://gigachat.devices.sberbank.ru/api/v1/embeddings"
-        ),
+        request=httpx.Request("POST", "https://gigachat.devices.sberbank.ru/api/v1/embeddings"),
     )
 
     _, _, swapped_result = logging_obj._success_handler_helper_fn(
@@ -6842,12 +6850,14 @@ def test_get_status_fields_ranks_guardrail_flagged_between_success_and_intervene
     request-level guardrail_status but never mask an intervention."""
     flagged = {"guardrail_status": "guardrail_flagged"}
 
-    assert _get_status_fields(
-        "success", [{"guardrail_status": "success"}, flagged], None
-    )["guardrail_status"] == "guardrail_flagged"
-    assert _get_status_fields(
-        "success", [flagged, {"guardrail_status": "guardrail_intervened"}], None
-    )["guardrail_status"] == "guardrail_intervened"
+    assert (
+        _get_status_fields("success", [{"guardrail_status": "success"}, flagged], None)["guardrail_status"]
+        == "guardrail_flagged"
+    )
+    assert (
+        _get_status_fields("success", [flagged, {"guardrail_status": "guardrail_intervened"}], None)["guardrail_status"]
+        == "guardrail_intervened"
+    )
 
 
 def test_get_error_information_redacts_provider_key_from_upstream_url():
@@ -6900,22 +6910,41 @@ async def test_classifier_audit_matches_provider_transport(provider: str) -> Non
 
             return httpx.Response(200, json=mock_responses_api_response(content).model_dump())
         if provider == "anthropic":
-            return httpx.Response(200, json={
-                "id": "msg-audit", "type": "message", "role": "assistant", "model": "claude-haiku-4-5",
-                "content": [{"type": "text", "text": content}], "stop_reason": "end_turn",
-                "usage": {"input_tokens": 10, "output_tokens": 5},
-            })
+            return httpx.Response(
+                200,
+                json={
+                    "id": "msg-audit",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-haiku-4-5",
+                    "content": [{"type": "text", "text": content}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                },
+            )
         if provider == "bedrock":
-            return httpx.Response(200, json={
-                "output": {"message": {"role": "assistant", "content": [{"text": content}]}},
-                "stopReason": "end_turn", "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
-                "metrics": {"latencyMs": 1},
-            })
-        return httpx.Response(200, json={
-            "id": "chatcmpl-audit", "object": "chat.completion", "created": 0, "model": "gpt-5.6",
-            "choices": [{"index": 0, "message": {"role": "assistant", "content": content}, "finish_reason": "stop"}],
-            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-        })
+            return httpx.Response(
+                200,
+                json={
+                    "output": {"message": {"role": "assistant", "content": [{"text": content}]}},
+                    "stopReason": "end_turn",
+                    "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+                    "metrics": {"latencyMs": 1},
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-audit",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "gpt-5.6",
+                "choices": [
+                    {"index": 0, "message": {"role": "assistant", "content": content}, "finish_reason": "stop"}
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            },
+        )
 
     async def capture(kwargs, response_obj, start_time, end_time):
         logs.put_nowait(kwargs["standard_logging_object"])
@@ -6926,11 +6955,15 @@ async def test_classifier_audit_matches_provider_transport(provider: str) -> Non
         handler.client = http_client
         client: Final = (
             AsyncAzureOpenAI(
-                api_key="transport-only", azure_endpoint="https://azure.invalid",
-                api_version="2025-04-01-preview", http_client=http_client,
+                api_key="transport-only",
+                azure_endpoint="https://azure.invalid",
+                api_version="2025-04-01-preview",
+                http_client=http_client,
             )
-            if provider == "azure" else AsyncOpenAI(api_key="transport-only", http_client=http_client)
-            if provider == "openai" else handler
+            if provider == "azure"
+            else AsyncOpenAI(api_key="transport-only", http_client=http_client)
+            if provider == "openai"
+            else handler
         )
         model: Final = {
             "openai": "openai/gpt-5.6",
@@ -6943,23 +6976,44 @@ async def test_classifier_audit_matches_provider_transport(provider: str) -> Non
         async def run(marker: str) -> None:
             if provider == "responses":
                 await litellm.aresponses(
-                    model=model, api_key="transport-only", client=client, max_output_tokens=128,
-                    instructions="classifier-rubric", input=marker,
+                    model=model,
+                    api_key="transport-only",
+                    client=client,
+                    max_output_tokens=128,
+                    instructions="classifier-rubric",
+                    input=marker,
                     metadata={"internal_call_origin": "autorouter_classifier"},
                     proxy_server_request={"body": {}, "originating_request_masked": {"input": f"source-only-{marker}"}},
-                    success_callback=[capture], num_retries=0,
+                    success_callback=[capture],
+                    num_retries=0,
                 )
                 return
             await litellm.acompletion(
-                model=model, api_key="transport-only", client=client, max_tokens=128,
-                aws_access_key_id="transport-only", aws_secret_access_key="transport-only", aws_region_name="us-east-1",
+                model=model,
+                api_key="transport-only",
+                client=client,
+                max_tokens=128,
+                aws_access_key_id="transport-only",
+                aws_secret_access_key="transport-only",
+                aws_region_name="us-east-1",
                 messages=[{"role": "system", "content": "classifier-rubric"}, {"role": "user", "content": marker}],
                 metadata={"internal_call_origin": "autorouter_classifier"},
                 proxy_server_request={"body": {}, "originating_request_masked": {"input": f"source-only-{marker}"}},
-                success_callback=[capture], num_retries=0,
-                **({"api_base": "https://azure.invalid", "api_version": "2025-04-01-preview"} if provider == "azure" else {}),
-                **({"extra_body": {"audit_context": "provider-extra"}, "extra_headers": {"X-Audit": "header-only-secret"}}
-                   if provider in ("openai", "azure") else {}),
+                success_callback=[capture],
+                num_retries=0,
+                **(
+                    {"api_base": "https://azure.invalid", "api_version": "2025-04-01-preview"}
+                    if provider == "azure"
+                    else {}
+                ),
+                **(
+                    {
+                        "extra_body": {"audit_context": "provider-extra"},
+                        "extra_headers": {"X-Audit": "header-only-secret"},
+                    }
+                    if provider in ("openai", "azure")
+                    else {}
+                ),
             )
 
         await asyncio.gather(run("request-one"), run("request-two"))
@@ -6983,14 +7037,17 @@ async def test_classifier_audit_matches_provider_transport(provider: str) -> Non
 @pytest.mark.parametrize("redaction", ["none", "global", "request", "header"])
 @pytest.mark.parametrize("status", ["success", "failure"])
 @pytest.mark.parametrize("call_type", ["completion", "acompletion", "responses", "aresponses"])
-def test_classifier_audit_obeys_message_logging_before_payload_emission(logging_obj, monkeypatch, redaction, status, call_type):
+def test_classifier_audit_obeys_message_logging_before_payload_emission(
+    logging_obj, monkeypatch, redaction, status, call_type
+):
     from litellm.litellm_core_utils.litellm_logging import get_standard_logging_object_payload
 
     monkeypatch.setattr(litellm, "turn_off_message_logging", redaction == "global")
     params: Final = {
-        "metadata": {"internal_call_origin": "autorouter_classifier", **(
-            {"headers": {"x-litellm-enable-message-redaction": "true"}} if redaction == "header" else {}
-        )},
+        "metadata": {
+            "internal_call_origin": "autorouter_classifier",
+            **({"headers": {"x-litellm-enable-message-redaction": "true"}} if redaction == "header" else {}),
+        },
         "proxy_server_request": {"body": {}, "originating_request_masked": {"input": "source-only"}},
     }
     logging_obj.call_type = call_type
@@ -7003,8 +7060,12 @@ def test_classifier_audit_obeys_message_logging_before_payload_emission(logging_
     )
     now: Final = datetime.datetime.now()
     payload: Final = get_standard_logging_object_payload(
-        kwargs={**logging_obj.model_call_details, "call_type": call_type}, init_response_obj={},
-        start_time=now, end_time=now, logging_obj=logging_obj, status=status,
+        kwargs={**logging_obj.model_call_details, "call_type": call_type},
+        init_response_obj={},
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status=status,
     )
     assert payload is not None
     if redaction == "none":


### PR DESCRIPTION
fix(proxy/logging): case-insensitive User-Agent header lookup in _get_user_agent_tags

Ensures User-Agent request tags are extracted regardless of header key casing.

Closes #40979

## TLDR

Problem this solves:

- Case-sensitive lookup misses `User-Agent` tags when header key is capitalized

How it solves it:

- Checks `User-Agent` header keys case-insensitively in `_get_user_agent_tags`

## User Flow

Before: a developer sends requests with capitalized `User-Agent` headers, but request logs record no `User-Agent` tags

1. They send POST https://litellm-domain/v1/chat/completions with header `User-Agent: curl/7.68.0`
2. The proxy processes the request and logs spend tracking data
3. They open https://litellm-domain/ui/?page=logs and see the request logged without any `User-Agent` tags

After: the same request carries `User-Agent` tags in spend logs and analytics

1. They send POST https://litellm-domain/v1/chat/completions with header `User-Agent: curl/7.68.0`
2. The proxy extracts the `User-Agent` header case-insensitively
3. They open https://litellm-domain/ui/?page=logs and see `User-Agent: curl` and `User-Agent: curl/7.68.0` tags logged

## Relevant issues

Fixes #40979

## Affected release

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Before (30f33a949b)

1. `_get_user_agent_tags({"headers": {"User-Agent": "curl/7.68.0"}})` returns `None` due to strict `"user-agent"` dictionary key check.

### After (a3bc212273)

1. `_get_user_agent_tags({"headers": {"User-Agent": "curl/7.68.0"}})` returns `["User-Agent: curl", "User-Agent: curl/7.68.0"]`.

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

## QA runbook

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR