### PR TITLE
fix(vertex_ai): resolve correct default max_tokens for versioned claude ids

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -2,7 +2,7 @@ import json
 import re
 import time
 from collections.abc import Callable, Mapping, Sequence
-from types import MappingProxyType
+from types import BuiltinFunctionType, FunctionType, MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, NoReturn, cast
 
 import httpx
@@ -323,7 +323,26 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
     @classmethod
     def get_config(cls, *, model: str | None = None):
-        config: Final = super().get_config()
+        # defaults configured on the base class (litellm.AnthropicConfig(max_tokens=...)) live on
+        # AnthropicConfig itself and must keep reaching subclass requests (vertex/azure claude)
+        base: Final = {  # mutable-ok: get_config returns a plain dict, same contract as the base impl
+            k: v
+            for k, v in AnthropicConfig.__dict__.items()
+            if not k.startswith("_")
+            and not isinstance(
+                v,
+                (
+                    FunctionType,
+                    BuiltinFunctionType,
+                    classmethod,
+                    staticmethod,
+                    property,
+                ),
+            )
+            and v is not None
+            and not callable(v)
+        }
+        config: Final = {**base, **super().get_config()}  # mutable-ok: one-shot merge, same dict contract
 
         # anthropic requires a default value for max_tokens
         if config.get("max_tokens") is None:
@@ -1986,7 +2005,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             optional_params["tools"] = tools
 
         ## Load Config
-        config: Final = litellm.AnthropicConfig.get_config(model=model)
+        config: Final = self.get_config(model=model)
         for k, v in config.items():
             if (
                 k not in optional_params

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py
@@ -9,6 +9,7 @@ from litellm.litellm_core_utils.prompt_templates.image_handling import RemoteMed
 from litellm.llms.base_llm.chat.transformation import LiteLLMLoggingObj
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import ModelResponse
+from litellm.utils import get_max_tokens
 
 from ....anthropic.chat.transformation import AnthropicConfig
 from .output_params_utils import sanitize_vertex_anthropic_output_params
@@ -57,6 +58,16 @@ class VertexAIAnthropicConfig(AnthropicConfig):
 
     def should_strip_billing_metadata(self) -> bool:
         return True
+
+    @staticmethod
+    def get_max_tokens_for_model(model: str | None = None) -> int:
+        if model is not None:
+            vertex_key: Final = f"vertex_ai/{model}"
+            if vertex_key in litellm.model_cost:
+                vertex_max: Final = get_max_tokens(vertex_key)
+                if vertex_max is not None:
+                    return vertex_max
+        return AnthropicConfig.get_max_tokens_for_model(model)
 
     def _add_context_management_beta_headers(self, beta_set: set, context_management: dict) -> None:
         """

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_transformation.py
@@ -775,3 +775,45 @@ def test_vertex_ai_anthropic_tool_based_response_format_still_upgrades_legacy_th
     assert "tools" in result_params
     assert result_params["thinking"] == {"type": "adaptive"}
     assert result_params["output_config"] == {"effort": "high"}
+
+
+def test_vertex_ai_anthropic_versioned_model_default_max_tokens(local_model_cost_map):
+    config = VertexAIAnthropicConfig()
+    data = config.transform_request(
+        model="claude-haiku-4-5@20251001",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    assert data["max_tokens"] == 64000
+
+    unversioned = config.transform_request(
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    assert unversioned["max_tokens"] == 64000
+
+
+def test_vertex_ai_anthropic_base_config_defaults_reach_subclass(local_model_cost_map):
+    from litellm import AnthropicConfig
+
+    AnthropicConfig(max_tokens=123, temperature=0.5)
+    try:
+        data = VertexAIAnthropicConfig().transform_request(
+            model="claude-haiku-4-5@20251001",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+    finally:
+        for attr in ("max_tokens", "temperature"):
+            if attr in AnthropicConfig.__dict__:
+                delattr(AnthropicConfig, attr)
+
+    assert data["max_tokens"] == 123
+    assert data["temperature"] == 0.5


### PR DESCRIPTION
Context: Supersedes #40376 (which was auto-closed when  was merged into  and deleted). Rebased cleanly on top of  where all 24 unit tests pass.

## TLDR
Problem this solves:
- versioned vertex claude ids got a silent 4096 max_tokens default
- PR #40374 / #31884 fixed the pricing map values (8192 → 64000), this PR provides the resolution half so those values are actually used at runtime.
- Without this resolution half, a request without max_tokens to a versioned id like  still goes out capped at 4096, because the bare id is not a cost-map key and the lookup never reaches the prefixed entry.

How it solves it:
-  now calls  so the vertex config resolves the right key
-  merges the base class dict underneath the subclass dict, so defaults configured on  keep applying to vertex and azure claude requests
-  tries the  prefixed key first, then falls back to the base lookup

Fixes #40363

## User Flow
Before: a proxy operator routes chat completions to  on Vertex and a client sends no :
1. The client sends Can't connect to litellm-domain:443 (Temporary failure in name resolution)

Temporary failure in name resolution at /usr/share/perl5/LWP/Protocol/http.pm line 49. with no 
2. The request goes up to Vertex with  even though the model supports 64000
3. Long responses stop early with  at exactly 4096 output tokens

After: the same request fills  from the real model cap:
1. The client sends the same POST with no 
2. The request goes up to Vertex with 
3. Long responses run to their natural stop instead of the 4096 cap

## Relevant issues
Fixes #40363
Supersedes #40376

## Pre-Submission checklist
- [x] I have added meaningful tests
- [x] All test files pass locally ( -> 24 passed)
- [x] My PR passes all required CI/CD checks
